### PR TITLE
Add target for PRMS catchments

### DIFF
--- a/1_fetch.R
+++ b/1_fetch.R
@@ -99,7 +99,7 @@ p1_targets_list <- list(
   # Downloaded from ScienceBase: https://www.sciencebase.gov/catalog/item/5362b683e4b0c409c6289bf6
   tar_target(
     p1_catchments_shp,
-    get_gf(out_dir = "1_fetch/out/",sb_id = '5362b683e4b0c409c6289bf6',sb_name = 'GeospatialFabricFeatures_02.zip'),
+    get_gf(out_dir = "1_fetch/out/",sb_id = '5362b683e4b0c409c6289bf6',sb_name = gf_data_select),
     format = "file"
   ),
   

--- a/1_fetch.R
+++ b/1_fetch.R
@@ -3,6 +3,7 @@ source("1_fetch/src/get_daily_nwis_data.R")
 source("1_fetch/src/get_inst_nwis_data.R")
 source('1_fetch/src/get_nlcd_LC.R')
 source("1_fetch/src/get_nhdplusv2.R")
+source("1_fetch/src/get_gf.R")
 
 p1_targets_list <- list(
   
@@ -93,6 +94,21 @@ p1_targets_list <- list(
   tar_target(
     p1_nhdv2reaches_sf,
     get_nhdv2_flowlines(drb_huc8s)),  
+  
+  # Download PRMS catchments for region 02
+  # Downloaded from ScienceBase: https://www.sciencebase.gov/catalog/item/5362b683e4b0c409c6289bf6
+  tar_target(
+    p1_catchments_shp,
+    get_gf(out_dir = "1_fetch/out/",sb_id = '5362b683e4b0c409c6289bf6',sb_name = 'GeospatialFabricFeatures_02.zip'),
+    format = "file"
+  ),
+  
+  # Read PRMS catchment shapefile into sf object and filter to DRB
+  tar_target(
+    p1_catchments_sf,
+    {st_read(dsn=p1_catchments_shp,layer="nhru") %>%
+      filter(hru_segment %in% p1_reaches_sf$subsegseg)}
+  ),
 
   # Download NLCD datasets 
   tar_target(

--- a/1_fetch/src/get_gf.R
+++ b/1_fetch/src/get_gf.R
@@ -1,0 +1,38 @@
+get_gf <- function(sb_id, sb_name, out_dir) {
+  
+  #' 
+  #' @description Function to download the national geospatial fabric (GF). This function is borrowed/has been modified from 
+  #' delaware-model-prep: https://github.com/USGS-R/delaware-model-prep/blob/main/1_network/src/get_national_gf.R
+  #'
+  #' @param sb_id character string indicating the ScienceBase identifier
+  #' @param sb_name string vector of file names attached to the ScienceBase item of interest
+  #' @param out_dir directory to save the downloaded GF files 
+  #'
+  #' @examples 
+  #' get_national_gf(out_dir = "1_fetch/out/", sb_id = '5362b683e4b0c409c6289bf6', sb_name = 'GeospatialFabricFeatures_01.gdb')
+  #'
+
+  # check against out_dir, if already present, don't download if not needed
+  if(grepl(".zip",sb_name)){
+    out_file <- tools::file_path_sans_ext(sb_name)
+    if(!grepl(".gdb",out_file)){
+    out_file <- paste0(out_file,".gdb")
+    }
+  } else {
+    out_file <- sb_name
+  }
+  out_path <- paste0(out_dir,out_file)
+
+  # if the data don't yet exist, download and unzip
+  if(!out_file %in% list.files(out_dir)) {
+    temp_loc <- tempfile()
+    sbtools::item_file_download(sb_id = sb_id, names = sb_name, destinations=temp_loc,overwrite_file = TRUE)
+    if(dir.exists(out_path)) unlink(out_file, recursive=TRUE)
+    unzip(temp_loc, exdir = dirname(out_path))
+  } else {
+    message('GF is already downloaded; doing nothing')
+  }
+  
+  return(out_path)
+  
+}

--- a/_targets.R
+++ b/_targets.R
@@ -58,6 +58,9 @@ earliest_date <- "1979-10-01"
 # Change dummy date to force re-build of NWIS SC sites and data download
 dummy_date <- "2021-12-13"
 
+# Define dataset of interest for the national geospatial fabric (used to fetch PRMS catchment polygons):
+gf_data_select <- 'GeospatialFabricFeatures_02.zip'
+
 # Define land cover datasets to extract 
 sb_ids_NLCD <- c(
   # ImperviousnessPct_2011: 'https://www.sciencebase.gov/catalog/item/57057a9be4b0d4e2b7571fbb',


### PR DESCRIPTION
The code changes here add two targets to the data pipeline: 

1. Download the geospatial fabric files; For this target I modified the function `get_national_gf.R` within the delaware-model-prep pipeline ([here](https://github.com/USGS-R/delaware-model-prep/blob/main/1_network/src/get_national_gf.R)). To save storage space and download time I've set up the target to only download the data from region 2 as opposed to the national data.
2. Load the catchments ("HRU's") from the downloaded GF and subset to the PRMS segments within the DRB

 