### PR TITLE
Pair NHDPlusV2 catchments to PRMS segments

### DIFF
--- a/2_process.R
+++ b/2_process.R
@@ -4,6 +4,7 @@ source("2_process/src/create_site_list.R")
 source("2_process/src/match_sites_reaches.R")
 source("2_process/src/pair_nhd_reaches.R")
 source("2_process/src/pair_nhd_catchments.R")
+source("2_process/src/create_GFv1_NHDv2_xwalk.R")
 
 p2_targets_list <- list(
   
@@ -47,21 +48,8 @@ p2_targets_list <- list(
   # Pair PRMS segments with intersecting NHDPlusV2 reaches and contributing NHDPlusV2 catchments
   tar_target(
     p2_prms_nhdv2_xwalk,
-    {
-      # find NHDPlusV2 COMID's that intersect PRMS segments
-      reach_to_seg_xwalk <- p1_reaches_sf %>%
-        split(.,.$subsegid) %>%
-        purrr::map(.,pair_nhd_reaches,nhd_lines=p1_nhdv2reaches_sf) %>%
-        purrr::map(.,summarize_paired_comids) %>%
-        bind_rows()
-      
-      # find NHDPlusV2 COMID's that drain directly to PRMS segments
-      p1_reaches_sf %>%
-        split(.,.$subsegid) %>%
-        purrr::map(.,pair_nhd_catchments,prms_hrus=p1_catchments_sf,min_area_overlap=0.5,nhd_lines=p1_nhdv2reaches_sf,xwalk_table = reach_to_seg_xwalk) %>%
-        bind_rows() %>%
-        left_join(reach_to_seg_xwalk,.,by="PRMS_segid")
-    }
+    create_GFv1_NHDv2_xwalk(prms_lines = p1_reaches_sf,nhd_lines = p1_nhdv2reaches_sf,prms_hrus = p1_catchments_sf,
+                            min_area_overlap = 0.5,drb_segs_spatial = drb_segs_spatial)
   ),
   
   # Filter discrete samples from sites thought to be influenced by tidal extent

--- a/2_process/src/create_GFv1_NHDv2_xwalk.R
+++ b/2_process/src/create_GFv1_NHDv2_xwalk.R
@@ -1,0 +1,37 @@
+create_GFv1_NHDv2_xwalk <- function(prms_lines,nhd_lines,prms_hrus,min_area_overlap,drb_segs_spatial){
+  #' 
+  #' @description This function outputs a table to facilitate cross-walking between PRMS river segments (from the
+  #' Geospatial Fabric, GFv1) and NHDPlusV2 flowlines and catchments for the Delaware River Basin (DRB). 
+  #' 
+  #' @param prms_lines sf object containing the PRMS river segments for the DRB
+  #' @param nhd_lines sf object containing NHDPlusV2 flowlines for area of interest
+  #' nhd_lines must contain variables COMID, PATHLENGTH, LENGTHKM, HYDROSEQ, STREAMORDE, STREAMCALC, FROMNODE,and TONODE
+  #' @param prms_hrus sf (multi)polygon containing the HRU's from the GFv1
+  #' @param min_area_overlap float; value indicating the minimum proportion of NHDPlusV2 catchment area that 
+  #' overlaps the PRMS polygon in order to be retained
+  #' @param drb_segs_spatial character vector containing the identity of PRMS segments that require special handling
+  #' For these segments, the contributing NHD catchments will be determined using a spatial join with the 
+  #' PRMS HRU polygons
+  #
+  
+  # find NHDPlusV2 COMID's that intersect PRMS segments
+  reach_to_seg_xwalk <- prms_lines %>%
+    split(.,.$subsegid) %>%
+    purrr::map(.,pair_nhd_reaches,nhd_lines = nhd_lines) %>%
+    purrr::map(.,summarize_paired_comids) %>%
+    bind_rows()
+  
+  # find NHDPlusV2 COMID's that drain directly to PRMS segments
+  cats_to_seg_xwalk <- prms_lines %>%
+    split(.,.$subsegid) %>%
+    purrr::map(.,pair_nhd_catchments,
+               prms_hrus = prms_hrus,
+               min_area_overlap = min_area_overlap,
+               nhd_lines = nhd_lines,
+               xwalk_table = reach_to_seg_xwalk,
+               drb_segs_spatial = drb_segs_spatial) %>%
+    bind_rows() %>%
+    left_join(reach_to_seg_xwalk,.,by="PRMS_segid")
+  
+  return(cats_to_seg_xwalk)
+}

--- a/2_process/src/pair_nhd_catchments.R
+++ b/2_process/src/pair_nhd_catchments.R
@@ -1,4 +1,4 @@
-pair_nhd_catchments <- function(prms_line,prms_hrus,min_area_overlap,xwalk_table,nhd_lines){
+pair_nhd_catchments <- function(prms_line,prms_hrus,min_area_overlap,xwalk_table,nhd_lines,drb_segs_spatial){
   #' @description This function finds the NHDPlusV2 catchments that overlap the HRU's for each PRMS segment in the DRB. 
   #' For the majority of DRB segments, this function finds the catchments that directly drain to a given segment 
   #' by navigating the NHDPlusV2 value-added attributes tables.  
@@ -14,6 +14,9 @@ pair_nhd_catchments <- function(prms_line,prms_hrus,min_area_overlap,xwalk_table
   #' @param xwalk_table data frame containing the NHDPlusV2/PRMS reach-to-segment crosswalk information
   #' @param nhd_lines sf object containing NHDPlusV2 flowlines for area of interest
   #' nhd_lines must contain variables COMID, PATHLENGTH, LENGTHKM, and HYDROSEQ
+  #' @param drb_segs_spatial character vector containing the identity of PRMS segments that require special handling
+  #' For these segments, the contributing NHD catchments will be determined using a spatial join with the 
+  #' PRMS HRU polygons
   #' 
   #' @examples pair_nhd_catchments(prms_line = p1_reaches_sf[p1_reaches_sf$subsegid == "3_1",],
   #'                               prms_hrus = p1_catchments_sf,
@@ -21,10 +24,6 @@ pair_nhd_catchments <- function(prms_line,prms_hrus,min_area_overlap,xwalk_table
   #'                               xwalk_table = p2_prms_nhdv2_xwalk,
   #'                               nhd_lines = p1_nhdv2reaches_sf)
   #'                               
-  
-  # Identify PRMS segments that require special handling
-  drb_segs_spatial <- c("31_1","135_1","233_1","236_1","244_1","249_1","332_1","354_1","355_1","358_1","396_1","593_1","1256_1","2137_1",
-                        "2138_1","2757_1","2758_1","2759_1","2765_1","2766_1","2767_1","2772_1","2797_1")
   
   if(prms_line$subsegid %in% drb_segs_spatial){
     # If PRMS segment requires special handling, find contributing NHDPlusV2 catchments through a spatial join with the corresponding PRMS HRU's
@@ -102,7 +101,7 @@ get_upstream_nhd_catchments <- function(nhd_lines,xwalk_table,prms_line){
   # Find all tributaries upstream of comid_down
   nhd_reach_down_UT <- nhdplusTools::get_UT(nhd_lines,xwalk_prms_line$comid_down)
   
-  # Find GF POI's (=respective comid_down's) that are upstream of the PRMS segment of interest
+  # Find Geospatial Fabric (GFv1) POI's (=respective comid_down's) that are upstream of the PRMS segment of interest
   ntw_POI <- xwalk_table %>%
     filter(PRMS_segid != prms_line$subsegid) %>%
     filter(comid_down %in% nhd_reach_down_UT) %>%

--- a/2_process/src/pair_nhd_catchments.R
+++ b/2_process/src/pair_nhd_catchments.R
@@ -1,0 +1,124 @@
+pair_nhd_catchments <- function(prms_line,prms_hrus,min_area_overlap,xwalk_table,nhd_lines){
+  #' @description This function finds the NHDPlusV2 catchments that overlap the HRU's for each PRMS segment in the DRB. 
+  #' For the majority of DRB segments, this function finds the catchments that directly drain to a given segment 
+  #' by navigating the NHDPlusV2 value-added attributes tables.  
+  #' For a subset of segments, the contributing area by NHD navigation differed considerably from the 
+  #' contributing area represented by the corresponding HRU polygons (based on visual inspection). This
+  #' function applies special handling for those select segments and uses a spatial join to 
+  #' find the NHDPlusV2 catchments that overlap the PRMS HRU's.
+  #' 
+  #' @param prms_line sf linestring containing a target PRMS segment
+  #' @param prms_hrus sf (multi)polygon containing the HRU's from the NHGF
+  #' @param min_area_overlap float; value indicating the minimum proportion of NHDPlusV2 catchment area that 
+  #' overlaps the PRMS polygon in order to be retained
+  #' @param xwalk_table data frame containing the NHDPlusV2/PRMS reach-to-segment crosswalk information
+  #' @param nhd_lines sf object containing NHDPlusV2 flowlines for area of interest
+  #' nhd_lines must contain variables COMID, PATHLENGTH, LENGTHKM, and HYDROSEQ
+  #' 
+  #' @examples pair_nhd_catchments(prms_line = p1_reaches_sf[p1_reaches_sf$subsegid == "3_1",],
+  #'                               prms_hrus = p1_catchments_sf,
+  #'                               min_area_overlap = 0.7,
+  #'                               xwalk_table = p2_prms_nhdv2_xwalk,
+  #'                               nhd_lines = p1_nhdv2reaches_sf)
+  #'                               
+  
+  # Identify PRMS segments that require special handling
+  drb_segs_spatial <- c("31_1","135_1","233_1","236_1","244_1","249_1","332_1","354_1","355_1","358_1","396_1","593_1","1256_1","2137_1",
+                        "2138_1","2757_1","2758_1","2759_1","2765_1","2766_1","2767_1","2772_1","2797_1")
+  
+  if(prms_line$subsegid %in% drb_segs_spatial){
+    # If PRMS segment requires special handling, find contributing NHDPlusV2 catchments through a spatial join with the corresponding PRMS HRU's
+    comid_cat <- get_intersecting_nhdplus_catchments(prms_line,prms_hrus,min_area_overlap)    
+  } else {
+    # Otherwise, find contributing NHDPlusV2 catchments by navigating upstream tributaries
+    comid_cat <- get_upstream_nhd_catchments(nhd_lines,xwalk_table,prms_line)
+  }
+  
+  return(comid_cat)
+  
+}
+
+
+
+get_intersecting_nhdplus_catchments <- function(prms_line,prms_hrus,min_area_overlap){
+  #' @description This function uses a spatial join to find the NHDPlusV2 catchments that overlap the PRMS HRU's.
+  #' 
+  #' @param prms_line sf linestring containing a target PRMS segment
+  #' @param prms_hrus sf (multi)polygon containing the HRU's from the NHGF
+  #' @param min_area_overlap float; value indicating the minimum proportion of NHDPlusV2 catchment area that 
+  #' overlaps the PRMS polygon in order to be retained
+  #' 
+  
+  # Select corresponding HRU polygon 
+  prms_poly <- prms_hrus %>% 
+    filter(hru_segment == prms_line$subsegseg) %>% 
+    st_union()
+  
+  if(length(st_geometry(prms_poly))>0){
+    
+    # Download NHDPlusV2 catchments and calculate original area
+    nhd_cats <- nhdplusTools::get_nhdplus(AOI = prms_poly,realization = "catchment") %>%
+      suppressMessages() %>%
+      mutate(area_orig = as.numeric(st_area(.)))
+    
+    # Find intersection between NHD catchments and HRU polygon and calculate *intersecting* area
+    nhd_cats_intrsct <- st_intersection(nhd_cats,prms_poly) %>%
+      suppressWarnings() %>%
+      mutate(area_int = as.numeric(st_area(.)),
+             area_prop = as.numeric(area_int/area_orig)) %>%
+      # retain NHD catchments that overlap >= X% of their area with the HRU polygon
+      filter(area_prop >= min_area_overlap)
+    
+    # Save intersecting catchment COMID's
+    comids_all <- data.frame(PRMS_segid = prms_line$subsegid,
+                             comid_cat = paste(sort(unique(nhd_cats_intrsct$featureid)),collapse=";"))
+    
+  } else {
+    comids_all <- data.frame(PRMS_segid = prms_line$subsegid,
+                             comid_cat = NA)
+  }
+  
+  return(comids_all)
+  
+}
+
+
+
+get_upstream_nhd_catchments <- function(nhd_lines,xwalk_table,prms_line){
+  #' @description This function finds the NHDPlusV2 catchments that directly drain to a given segment 
+  #' by navigating the NHDPlusV2 value-added attributes tables using the information in the 
+  #' NHDPlus/PRMS reach-to-segment xwalk table
+  #' 
+  #' @param prms_line sf linestring containing a target PRMS segment
+  #' @param xwalk_table data frame containing the NHDPlusV2/PRMS reach-to-segment crosswalk information
+  #' @param nhd_lines sf object containing NHDPlusV2 flowlines for area of interest
+  #' nhd_lines must contain variables COMID, PATHLENGTH, LENGTHKM, and HYDROSEQ
+  #' 
+    
+  # subset xwalk for prms_line
+  xwalk_prms_line <- xwalk_table %>%
+    filter(PRMS_segid == prms_line$subsegid)
+  
+  # Find all tributaries upstream of comid_down
+  nhd_reach_down_UT <- nhdplusTools::get_UT(nhd_lines,xwalk_prms_line$comid_down)
+  
+  # Find GF POI's (=respective comid_down's) that are upstream of the PRMS segment of interest
+  ntw_POI <- xwalk_table %>%
+    filter(PRMS_segid != prms_line$subsegid) %>%
+    filter(comid_down %in% nhd_reach_down_UT) %>%
+    select(-comid_seg) 
+  
+  # Find all upstream tributaries for each upstream GF POI
+  ntw_POI_UT <- lapply(ntw_POI$comid_down,nhdplusTools::get_UT,network=nhd_lines) %>%
+    do.call("c",.)
+  
+  # By difference, find the tributaries that contribute directly to prms_line
+  nhd_reach_diff <- setdiff(nhd_reach_down_UT,ntw_POI_UT)
+  
+  # Save contributing catchment COMID's
+  comids_all <- data.frame(PRMS_segid = prms_line$subsegid,
+                           comid_cat = paste(sort(nhd_reach_diff),collapse=";"))
+  
+  return(comids_all)
+  
+}

--- a/2_process/src/pair_nhd_reaches.R
+++ b/2_process/src/pair_nhd_reaches.R
@@ -109,17 +109,17 @@ summarize_paired_comids <- function(paired_nhd_df){
   #'
   #' @param paired_nhd_df data frame containing the paired NHDPlusV2 reaches associated with each PRMS segment,
   #' where each row represents one PRMS segment. comid_down contains the NHDPlusV2 reach at the downstream
-  #' end of the PRMS segment, whereas comid_all represents all of the contributing NHDPlusV2 reaches.
+  #' end of the PRMS segment, whereas comid_seg represents all of the contributing NHDPlusV2 reaches.
   
   comids_out <- paired_nhd_df %>%
     group_by(PRMS_segid) %>% 
-    # concatenate all paired NHDPlusV2 reaches into one column, comid_all
-    mutate(comid_all = paste(sort(unique(COMID)),collapse=";")) %>%
+    # concatenate all paired NHDPlusV2 reaches into one column, comid_seg
+    mutate(comid_seg = paste(sort(unique(COMID)),collapse=";")) %>%
     ungroup() %>%
     # identify most downstream NHDPlusV2 reach (comid_down) for each PRMS segment that does not represent a divergence
     filter(STREAMORDE==STREAMCALC) %>%
     filter(HYDROSEQ==min(HYDROSEQ)) %>% 
-    select(PRMS_segid,COMID,comid_all) %>%
+    select(PRMS_segid,COMID,comid_seg) %>%
     rename(comid_down = COMID)
   
   return(comids_out)

--- a/_targets.R
+++ b/_targets.R
@@ -54,6 +54,10 @@ mainstem_reaches_tidal <- c("2771_1","2769_1","2768_1","2767_1","2764_1","2762_1
                             "2753_1","2755_1","2772_1","388_1","389_1","385_1","386_1","383_1","382_1","377_1","378_1",
                             "376_1","351_1","344_1","346_1","333_1")
 
+# Define PRMS segments that require special handling for the Geospatial Fabric (GFv1) to NHDplusV2 crosswalk target
+drb_segs_spatial <- c("31_1","135_1","233_1","236_1","244_1","249_1","332_1","354_1","355_1","358_1","396_1","593_1","1256_1","2137_1",
+                      "2138_1","2757_1","2758_1","2759_1","2765_1","2766_1","2767_1","2772_1","2797_1")
+
 # Define USGS stat codes for continuous sites that only report daily statistics (https://help.waterdata.usgs.gov/stat_code) 
 stat_cd_select <- c("00001","00003")
 


### PR DESCRIPTION
This PR makes edits to the prms-nhdv2 crosswalk target such that the target now contains a column called `comid_cat` that represents all of the COMIDs that drain directly to each PRMS segment ID in the DRB. The format of this column is the same as before. Additional details and discussion are in issue #45.