### PR TITLE
Fetch natural baseflow data

### DIFF
--- a/1_fetch.R
+++ b/1_fetch.R
@@ -5,6 +5,7 @@ source("1_fetch/src/find_sites_multipleTS.R")
 source('1_fetch/src/get_nlcd_LC.R')
 source("1_fetch/src/get_nhdplusv2.R")
 source("1_fetch/src/get_gf.R")
+source("1_fetch/src/fetch_sb_data.R")
 
 p1_targets_list <- list(
   
@@ -145,6 +146,16 @@ p1_targets_list <- list(
     p1_vars_of_interest,
     read_csv(p1_vars_of_interest_csv, show_col_types = FALSE)
   ),
+  
+  # Download monthly natural baseflow for the DRB
+  # from Miller et al. 2021: https://www.sciencebase.gov/catalog/item/6023e628d34e31ed20c874e4
+  tar_target(
+    p1_natural_baseflow_zip,
+    download_sb_file(sb_id = "6023e628d34e31ed20c874e4",
+                     file_name = "baseflow_partial_model_pred_XX.zip",
+                     out_dir="1_fetch/out"),
+    format = "file"
+  )
 
 )
   

--- a/1_fetch.R
+++ b/1_fetch.R
@@ -155,6 +155,16 @@ p1_targets_list <- list(
                      file_name = "baseflow_partial_model_pred_XX.zip",
                      out_dir="1_fetch/out"),
     format = "file"
+  ),
+  
+  # Unzip monthly natural baseflow file
+  tar_target(
+    p1_natural_baseflow_csv,
+    {
+      unzip(zipfile=p1_natural_baseflow_zip,exdir = dirname(p1_natural_baseflow_zip),overwrite=TRUE)
+      file.path(dirname(p1_natural_baseflow_zip), list.files(path = dirname(p1_natural_baseflow_zip),pattern = "*.csv"))
+      },
+    format = "file"
   )
 
 )

--- a/1_fetch.R
+++ b/1_fetch.R
@@ -118,10 +118,11 @@ p1_targets_list <- list(
   
   ## Unzip all NLCD downloaded datasets 
   ## Note - this returns a string or vector of strings of data path to unzipped datasets 
-  tar_target(p1_NLCD_data_unzipped, 
-             unzip_NHD_NLCD_data(downloaded_data_folder_path = p1_NLCD_data_zipped,
-                                 create_unzip_subfolder = T),
-             format = 'file'
+  tar_target(
+    p1_NLCD_data_unzipped, 
+    unzip_NHD_NLCD_data(downloaded_data_folder_path = p1_NLCD_data_zipped,
+                        create_unzip_subfolder = T),
+    format = 'file'
   ),
   
   ## read in NLCD datasets and subet by comid in DRB
@@ -130,19 +131,20 @@ p1_targets_list <- list(
              read_subset_LC_data(LC_data_folder_path = p1_NLCD_data_unzipped, 
                                  Comids_in_AOI_df = p1_nhdv2reaches_sf %>% st_drop_geometry() %>% select(COMID), 
                                  Comid_col = 'COMID')
-             ),
-
+  ),
 
   # csv of variables from the Wieczorek dataset that are of interest 
-  tar_target(p1_vars_of_interest_csv,
-             '1_fetch/in/NHDVarsOfInterest.csv',
-             format = 'file'
-             ),
+  tar_target(
+    p1_vars_of_interest_csv,
+    '1_fetch/in/NHDVarsOfInterest.csv',
+    format = 'file'
+  ),
 
   # variables from the Wieczorek dataset that are of interest 
-  tar_target(p1_vars_of_interest,
-             read_csv(p1_vars_of_interest_csv, show_col_types = FALSE)
-             )
+  tar_target(
+    p1_vars_of_interest,
+    read_csv(p1_vars_of_interest_csv, show_col_types = FALSE)
+  ),
 
 )
   

--- a/1_fetch/src/fetch_sb_data.R
+++ b/1_fetch/src/fetch_sb_data.R
@@ -1,0 +1,19 @@
+download_sb_file <- function(sb_id, file_name, out_dir){
+  #'
+  #' @description Function to download file from ScienceBase 
+  #'
+  #' @param sb_id string - the id of the science base item
+  #' @param file_name string - the name of the file in the science base item to download
+  #' @param out_dir string - the directory where you want the file downloaded to
+  #'
+  #' @value string the out_path
+
+  out_path = file.path(out_dir, file_name)
+  # Get the data from ScienceBase:
+  sbtools::item_file_download(sb_id = sb_id,
+                              names = file_name,
+                              destinations = out_path,
+                              overwrite_file = TRUE)
+  
+  return(out_path)
+}

--- a/2_process.R
+++ b/2_process.R
@@ -5,6 +5,7 @@ source("2_process/src/match_sites_reaches.R")
 source("2_process/src/pair_nhd_reaches.R")
 source("2_process/src/pair_nhd_catchments.R")
 source("2_process/src/create_GFv1_NHDv2_xwalk.R")
+source("2_process/src/munge_natural_baseflow.R")
 
 p2_targets_list <- list(
   
@@ -62,6 +63,17 @@ p2_targets_list <- list(
     p2_site_list_nontidal_csv,
     create_site_list_nontidal(p2_wqp_SC_filtered,p1_nwis_sites,p1_daily_data,p1_inst_data,
                               hucs=drb_huc8s,crs_out="NAD83",p2_sites_w_segs,"2_process/out/DRB_SC_sitelist_nontidal.csv"),
-    format = "file")
+    format = "file"),
+  
+  # Return natural baseflow estimates for each PRMS segment
+  tar_target(
+    p2_natural_baseflow,
+    munge_natural_baseflow(baseflow_pred_files = p1_natural_baseflow_csv,
+                           segs_w_comids = p2_prms_nhdv2_xwalk %>% 
+                             select(PRMS_segid,comid_down) %>% 
+                             rename('COMID' = 'comid_down'),
+                           start_year = as.character(lubridate::year(earliest_date)),end_year = "2021")
+      
+  )
 
 )

--- a/2_process/src/munge_natural_baseflow.R
+++ b/2_process/src/munge_natural_baseflow.R
@@ -1,0 +1,81 @@
+munge_natural_baseflow <- function(baseflow_pred_files,segs_w_comids,vars=c("mean","med","p10","p90"),start_year,end_year){
+  #' 
+  #' @description This function reads in the DRB monthly baseflow tables from Miller et al. 2021 (https://doi.org/10.5066/P9FZG7GZ)
+  #' and outputs a data frame containing monthly baseflow estimates for each PRMS segment. The Miller et al. dataset spans
+  #' years 1950-2015. If variable {end_year} is later than 2015, monthly values will be filled with long-term monthly averages from
+  #' {start_year} to 2015. 
+  #' 
+  #' @param baseflow_pred_files file paths of unzipped monthly baseflow tables, including file extension
+  #' @param segs_w_comids data frame containing the DRB PRMS segment ids and the comids of interest
+  #' segs_w_comids must contain variables PRMS_segid and comid
+  #' @param vars columns from monthly baseflow tables to retain; can include one or all of "mean","med","p10",or "p90", 
+  #' default is to retain all four columns
+  #' @param start_year character string indicating the earliest year to return and to include in long-term average monthly baseflows
+  #' @param end_year character string indicating the latest year to return and to include in long-term average monthly baseflows
+  #'                                           
+  
+  # Read in monthly baseflow files
+  monthly_baseflow_ls <- lapply(baseflow_pred_files,function(x){
+    
+    # Extract the month for each monthly baseflow file
+    # this line finds numbers with 2 digits within the file name string
+    month <- str_extract(x, "[0-9]{2}")
+    
+    # Read in monthly tables
+    data <- read_csv(x,show_col_types = FALSE) %>%
+      # reformat column names to include month
+      rename_with(.cols = p10.Pred:mean.Pred, function(x){paste0(x,"_", month)}) %>%
+      # subset dates
+      filter(Year >= start_year, Year <= end_year) %>%
+      # retain only desired COMIDs
+      filter(COMID %in% segs_w_comids$COMID) %>%
+      # add PRMS segment IDs
+      left_join(.,segs_w_comids,by="COMID") %>%
+      # order by year
+      arrange(Year)
+    
+  })
+  
+  # Combine monthly data frames into one table (join by shared cols, "PRMS_segid", "COMID" and "Year")    
+  monthly_baseflow <- Reduce(inner_join, monthly_baseflow_ls) %>%
+    suppressMessages() %>%
+    select(c(PRMS_segid,COMID,Year,contains(vars))) %>%
+    # Pivot table to long format so that rows contain data for different months
+    pivot_longer(!c(PRMS_segid,COMID,Year), names_to = "var_long", values_to = "Value") %>%
+    # Clean up month/variable names
+    mutate(Month = str_extract(var_long,"([^_]+$)"),
+           Var = str_extract(var_long,".*(?=\\.)")) %>%
+    select(PRMS_segid,COMID,Year,Var,Month,Value) %>%
+    # Pivot table back to wide format so that desired vars are represented as separate columns
+    pivot_wider(names_from = Var, values_from = Value) %>%
+    rename_with(.cols = all_of(vars),function(x){paste0(x,"_natl_baseflow_cfs")})
+  
+  # For each COMID, calculate average monthly natural flow for years {start_year} to {end_year}
+  monthly_baseflow_avg <- monthly_baseflow %>%
+    group_by(PRMS_segid,COMID,Month) %>%
+    summarize(across(contains(vars),mean),
+              .groups="drop")
+  
+  # If {end_year} > last year in monthly baseflow table, fill in missing years using long-term monthly averages
+  years_to_fill <- seq(start_year,end_year)[which(seq(start_year,end_year) %in% unique(monthly_baseflow$Year) == "FALSE")]
+  
+  if(length(years_to_fill)>0){
+    monthly_baseflow_fill <- years_to_fill %>%
+      lapply(.,function(x){
+        monthly_baseflow_avg$Year <- x
+        return(monthly_baseflow_avg)
+        }) %>%
+      bind_rows() %>%
+      relocate("Year",.after="COMID")
+    
+    # Bind dynamic monthly natural baseflow with long-term monthly averages to fill missing years
+    monthly_baseflow_out <- bind_rows(monthly_baseflow,monthly_baseflow_fill) %>%
+      select(-COMID)
+    } else {
+      monthly_baseflow_out <- monthly_baseflow %>%
+        select(-COMID)
+    }
+  
+  return(monthly_baseflow_out)
+  
+}


### PR DESCRIPTION
This PR fetches natural baseflow estimates for the DRB from ScienceBase (Miller et al. 2021). The monthly natural baseflow estimates are referenced to NHDPlusV2 COMIDs so the code changes here use the crosswalk table to:

- identify the COMID at the downstream end of each PRMS segment, 
- return the monthly estimates for those COMIDs, and 
- munge the data into a single output table containing monthly natural baseflow estimates from 1979-2021 for each PRMS segment 
 
Some additional discussion of processing steps is in issue #43.

