### PR TITLE
Gather NHDv2 attributes referenced to upstream watershed (TOT/ACC)

### DIFF
--- a/2_process.R
+++ b/2_process.R
@@ -5,6 +5,7 @@ source("2_process/src/match_sites_reaches.R")
 source("2_process/src/raster_to_catchment_polygons.R")
 source("2_process/src/combine_NLCD_PRMS.R")
 source("2_process/src/munge_natural_baseflow.R")
+source("2_process/src/process_nhdv2_attr.R")
 
 p2_targets_list <- list(
   
@@ -170,6 +171,20 @@ p2_targets_list <- list(
                     setNames(gsub('_\\d{4}', '', names(.)))) %>%
                # rbind the list of cleaned dfs
       do.call(rbind, .)
+  ),
+  
+  # Process NHDv2 attributes referenced to cumulative upstream area;
+  # returns object target of class "list". List elements for CAT_PPT
+  # and ACC_PPT (if TOT is selected below) will only contain the 
+  # PRMS_segid and so will functionally be omitted in the target that 
+  # combines the output of p2_nhdv2_attr_upstream and p2_nhdv2_attr_catchment (forthcoming)
+  tar_target(
+    p2_nhdv2_attr_upstream,
+    process_cumulative_nhdv2_attr(p1_vars_of_interest_downloaded_csvs,
+                                  segs_w_comids = p2_drb_comids_seg,
+                                  cols = c("TOT")),
+    pattern = map(p1_vars_of_interest_downloaded_csvs),
+    iteration = "list"
   )
   
 )

--- a/2_process.R
+++ b/2_process.R
@@ -67,9 +67,9 @@ p2_targets_list <- list(
       rename(comid = comid_cat)
   ),
   
-  # Melt PRMS-NHDv2 xwalk table to return the COMID located at the downstream end of each PRMS segment
+  # Subset PRMS-NHDv2 xwalk table to return the COMID located at the downstream end of each PRMS segment
   tar_target(
-    p2_drb_comids_seg,
+    p2_drb_comids_down,
     p2_prms_nhdv2_xwalk %>% 
       select(PRMS_segid,comid_down) %>% 
       rename(comid = comid_down)
@@ -181,7 +181,7 @@ p2_targets_list <- list(
   tar_target(
     p2_nhdv2_attr_upstream,
     process_cumulative_nhdv2_attr(p1_vars_of_interest_downloaded_csvs,
-                                  segs_w_comids = p2_drb_comids_seg,
+                                  segs_w_comids = p2_drb_comids_down,
                                   cols = c("TOT")),
     pattern = map(p1_vars_of_interest_downloaded_csvs),
     iteration = "list"

--- a/2_process.R
+++ b/2_process.R
@@ -57,13 +57,21 @@ p2_targets_list <- list(
     read_csv(GFv1_NHDv2_xwalk_url, col_types = 'cccc')
   ),
   
-  ## Melt PRMS_nhdv2_xwalk to get all cols of comids Ids and PRMS ids filtered to drb 
+  # Melt PRMS-NHDv2 xwalk table to return all COMIDs that drain to each PRMS segment
   tar_target(
     p2_drb_comids_all_tribs, 
     p2_prms_nhdv2_xwalk %>%
       select(PRMS_segid, comid_cat) %>% 
       tidyr::separate_rows(comid_cat,sep=";") %>% 
       rename(comid = comid_cat)
+  ),
+  
+  # Melt PRMS-NHDv2 xwalk table to return the COMID located at the downstream end of each PRMS segment
+  tar_target(
+    p2_drb_comids_seg,
+    p2_prms_nhdv2_xwalk %>% 
+      select(PRMS_segid,comid_down) %>% 
+      rename(comid = comid_down)
   ),
   
   ## Filter LC data to the AOI : DRB and join with COMIDs area info and PRMS ids
@@ -108,7 +116,6 @@ p2_targets_list <- list(
              summarise(across(starts_with('rd_sltX'), sum)))
   ),
   
-  
   # Combine rd salt targets - from list of dfs to single df with added columns that summarize salt accumulation across all years. 
   tar_target(
     p2_rdsalt_per_catchment_allyrs,
@@ -147,7 +154,6 @@ p2_targets_list <- list(
                            start_year = as.character(lubridate::year(earliest_date)),
                            end_year = as.character(lubridate::year(dummy_date)),
                            fill_all_years = TRUE)
-    
   ),
 
   # Target for NADP initial Processing  
@@ -165,6 +171,7 @@ p2_targets_list <- list(
                # rbind the list of cleaned dfs
       do.call(rbind, .)
   )
+  
 )
 
 

--- a/2_process/src/process_nhdv2_attr.R
+++ b/2_process/src/process_nhdv2_attr.R
@@ -1,0 +1,88 @@
+calc_monthly_avg_ppt <- function(ppt_data){
+  #' 
+  #' @description Function to calculate long-term monthly average precipitation for each NHDPlusV2 reach, represented by a unique COMID
+  #'
+  #' @param ppt_data data frame containing monthly precipitation data for all COMIDs of interest; downloaded from ScienceBase.
+  #' Note that we are expecting the years represented in ppt_data to span the 30-year period including 1971-2000, and 
+  #' this function will error out if years before 1971 or after 2000 are detected. 
+  #'
+  #' @value returns a data frame with one row per COMID and one column to contain each of 12 long-term monthly averages
+  #'
+  
+  # Check that years represented in PPT column names include the time period we were expecting
+  years <- ppt_data %>%
+    names(.) %>%
+    str_extract(.,"[[\\d]]+") %>%
+    unique(.) %>%
+    as.numeric(.) %>%
+    range(.,na.rm=TRUE)
+  
+  if(years[1] < 1971 | years[2] > 2000){
+    stop(paste("For PPT data, we expected years 1971-2000 but the downloaded data contains other years: ",
+               paste(years,collapse= ' - '),
+               ". In 1_fetch/in/NHDVarsOfInterest.csv, check column sb_item_retrieve for Dataset_name PPT_CAT, PPT_TOT, and PPT_ACC."))
+  }
+  
+  # Group columns by month and calculate the long-term monthly average precipitation
+  # return a data frame with one row per COMID and one column to contain each of 12 long-term monthly averages
+  ppt_data_summarized <- ppt_data %>%
+    pivot_longer(!COMID, names_to = "month_yr", values_to = "value") %>%
+    mutate(month = str_replace(month_yr,"[[\\d]]+","")) %>%
+    group_by(COMID,month) %>%
+    summarize(mean_monthly_ppt = mean(value,na.rm = TRUE),
+              .groups="drop") %>%
+    pivot_wider(names_from = month, values_from = mean_monthly_ppt)
+  
+  return(ppt_data_summarized)
+  
+}
+
+
+
+process_cumulative_nhdv2_attr <- function(file_path,segs_w_comids,cols){
+  #' 
+  #' @description Function to read in downloaded NHDv2 attribute data and join with river segment ID's
+  #'
+  #' @param file_path file path of downloaded NHDv2 attribute data table, including file extension
+  #' @param segs_w_comids data frame containing the PRMS segment ids and the comids of interest
+  #' segs_w_comids must contain variables PRMS_segid and COMID
+  #' @param cols character string indicating which columns to retain from downloaded attribute data; 
+  #' cols can take values "ACC" or "TOT"
+  #'
+  #' @value A data frame containing PRMS_id and columns representing the NHDv2 attribute data referenced to the 
+  #' cumulative upstream watershed.
+  #' 
+
+  # Read in downloaded data 
+  # only specify col_type for COMID since cols will differ for each downloaded data file
+  dat <- read_csv(file_path, col_types = cols(COMID = "c"), show_col_types = FALSE)
+  
+  # For PPT data we want to return the long-term (1971-2000) monthly averages 
+  # instead of the monthly values for each year
+  if(grepl("PPT_TOT",file_path)|grepl("PPT_ACC",file_path)){
+    message("Calculating long-term monthly average precipitation from annual data")
+    dat <- calc_monthly_avg_ppt(dat)
+  }
+    
+  # Process downloaded data
+  dat_proc <- dat %>%
+    # retain desired columns ('ACC' or 'TOT')
+    select(c(COMID,starts_with(cols))) %>%
+    # join data to {segs_w_comids} data frame by COMID
+    right_join(.,segs_w_comids,by=c("COMID"="comid")) %>%
+    relocate("PRMS_segid",.before="COMID") %>%
+    select(-COMID)
+  
+  # Flag columns with undesired flag values (e.g. -9999)
+  flag_cols <- dat_proc %>%
+    select(where(function(x) -9999 %in% x)) %>% 
+    names()
+  
+  # For columns with undesired flag values, replace -9999 with NA, else use existing value
+  dat_proc_out <- dat_proc %>%
+    mutate(across(all_of(flag_cols), ~case_when(. == -9999 ~ NA_real_, TRUE ~ as.numeric(.))))
+
+  return(dat_proc_out)
+  
+}
+

--- a/3_visualize.R
+++ b/3_visualize.R
@@ -66,7 +66,9 @@ p3_targets_list <- list(
   # Plot distribution of NHDv2 attribute variables across the PRMS network
   tar_target(
     p3_nhdv2_attr_upstream_png,
-    plot_nhdv2_attr(p2_nhdv2_attr_upstream,"3_visualize/out/nhdv2_attr_png"),
+    plot_nhdv2_attr(attr_data = p2_nhdv2_attr_upstream,
+                    network_geometry = p1_reaches_sf,
+                    file_path = "3_visualize/out/nhdv2_attr_png"),
     format = "file"
   ),
   

--- a/3_visualize.R
+++ b/3_visualize.R
@@ -3,6 +3,7 @@ source("3_visualize/src/plot_inst_data.R")
 source("3_visualize/src/map_SC_sites.R")
 source("3_visualize/src/summarize_site_list.R")
 source("3_visualize/src/summarize_timeseries.R")
+source("3_visualize/src/plot_nhdv2_attr.R")
 
 p3_targets_list <- list(
   
@@ -59,6 +60,14 @@ p3_targets_list <- list(
   ),
   
   # Render data summary report (note that tar_render returns a target with format="file") 
-  tarchetypes::tar_render(p3_SC_report, "3_visualize/src/report-wqp-salinity-data.Rmd",output_dir = "3_visualize/out")
+  tarchetypes::tar_render(p3_SC_report, "3_visualize/src/report-wqp-salinity-data.Rmd",output_dir = "3_visualize/out"),
+  
+  # Plot distribution of NHDv2 attribute variables across the PRMS network
+  tar_target(
+    p3_nhdv2_attr_upstream_png,
+    plot_nhdv2_attr(p2_nhdv2_attr_upstream,"3_visualize/out/nhdv2_attr_png"),
+    format = "file"
+  )
+  
 )
 

--- a/3_visualize.R
+++ b/3_visualize.R
@@ -4,6 +4,7 @@ source("3_visualize/src/map_SC_sites.R")
 source("3_visualize/src/summarize_site_list.R")
 source("3_visualize/src/summarize_timeseries.R")
 source("3_visualize/src/plot_nhdv2_attr.R")
+source("3_visualize/src/summarize_nhdv2_attr.R")
 
 p3_targets_list <- list(
   
@@ -66,6 +67,13 @@ p3_targets_list <- list(
   tar_target(
     p3_nhdv2_attr_upstream_png,
     plot_nhdv2_attr(p2_nhdv2_attr_upstream,"3_visualize/out/nhdv2_attr_png"),
+    format = "file"
+  ),
+  
+  # Create and save a summary table that describes variation in the NHDv2 attribute variables across the PRMS network
+  tar_target(
+    p3_nhdv2_attr_summary_csv,
+    summarize_nhdv2_attr(p2_nhdv2_attr_upstream,"3_visualize/out/nhdv2_attr_summary.csv"),
     format = "file"
   )
   

--- a/3_visualize/src/plot_nhdv2_attr.R
+++ b/3_visualize/src/plot_nhdv2_attr.R
@@ -1,0 +1,58 @@
+plot_nhdv2_attr <- function(attr_data,file_path){
+  #' 
+  #' @description This function visualizes each of the downloaded NHDv2 attribute variables across all river segments within the network
+  #'
+  #' @param attr_data list containing the processed NHDv2 attribute data; data frames must include column "PRMS_segid" 
+  #' @param file_path a character string that indicates the location of the saved plot
+  #'
+  #' @value Returns a png file containing a violin plot showing distribution of each NHDv2 attribute variable
+  
+  message("Plotting individual NHDv2 attribute variables")
+  
+  # Bind all columns representing unique NHDv2 attribute variables
+  attr_data_df <- attr_data %>%
+    Reduce(full_join,.) %>%
+    # hide messages that data frames are being joined by column 'PRMS_segid'
+    suppressMessages()
+  
+  plot_names <- c("")
+  
+  # For each column/attribute variable, plot the distribution of the data across all PRMS segments
+  for(i in 2:dim(attr_data_df)[2]){
+    
+    dat_subset <- attr_data_df[,c(1,i)]
+    col_name <- names(dat_subset)[2]
+    
+    # linear scale
+    attr_plot <- dat_subset %>%
+      ggplot(aes(x = "", y = .data[[col_name]])) + 
+      geom_violin(draw_quantiles = c(0.5)) +
+      geom_jitter(height=0,color = "steelblue",alpha=0.5,width=0.2) +
+      labs(x="") + 
+      theme_bw()
+    
+    # log scale
+    attr_plot_log <- dat_subset %>%
+      ggplot(aes(x = "", y = (.data[[col_name]]+0.01))) + 
+      geom_violin(draw_quantiles = c(0.5)) +
+      geom_jitter(height=0,color = "steelblue",alpha=0.5,width=0.2) +
+      scale_y_log10() + 
+      labs(x="",y = paste0("log[10]  ",col_name," + 0.01")) + 
+      theme_bw()
+    
+    attr_plot_combined <- attr_plot + attr_plot_log + patchwork::plot_layout(ncol=2)
+    
+    plot_name <- paste0(file_path,"/",col_name,".png")
+    plot_names <- c(plot_names,plot_name)
+    
+    suppressWarnings(ggsave(plot_name,plot = attr_plot_combined,width=7,height=4,device = "png"))
+    
+  }
+  
+  plot_names <- plot_names[-1]
+  
+  return(plot_names)
+  
+}
+
+

--- a/3_visualize/src/plot_nhdv2_attr.R
+++ b/3_visualize/src/plot_nhdv2_attr.R
@@ -1,8 +1,9 @@
-plot_nhdv2_attr <- function(attr_data,file_path){
+plot_nhdv2_attr <- function(attr_data,network_geometry,file_path){
   #' 
   #' @description This function visualizes each of the downloaded NHDv2 attribute variables across all river segments within the network
   #'
   #' @param attr_data list containing the processed NHDv2 attribute data; data frames must include column "PRMS_segid" 
+  #' @param network_geometry sf object containing the network flowline geometry
   #' @param file_path a character string that indicates the location of the saved plot
   #'
   #' @value Returns a png file containing a violin plot showing distribution of each NHDv2 attribute variable
@@ -15,7 +16,7 @@ plot_nhdv2_attr <- function(attr_data,file_path){
     # hide messages that data frames are being joined by column 'PRMS_segid'
     suppressMessages()
   
-  plot_names <- c("")
+  plot_names <- vector('character', length = 0L)
   
   # For each column/attribute variable, plot the distribution of the data across all PRMS segments
   for(i in 2:dim(attr_data_df)[2]){
@@ -23,33 +24,36 @@ plot_nhdv2_attr <- function(attr_data,file_path){
     dat_subset <- attr_data_df[,c(1,i)]
     col_name <- names(dat_subset)[2]
     
-    # linear scale
+    # plot the distribution of attr values on a linear scale
     attr_plot <- dat_subset %>%
       ggplot(aes(x = "", y = .data[[col_name]])) + 
       geom_violin(draw_quantiles = c(0.5)) +
       geom_jitter(height=0,color = "steelblue",alpha=0.5,width=0.2) +
       labs(x="") + 
-      theme_bw()
+      theme_bw() + 
+      theme(plot.margin = unit(c(0,0,0,0), "cm"))
     
-    # log scale
-    attr_plot_log <- dat_subset %>%
-      ggplot(aes(x = "", y = (.data[[col_name]]+0.01))) + 
-      geom_violin(draw_quantiles = c(0.5)) +
-      geom_jitter(height=0,color = "steelblue",alpha=0.5,width=0.2) +
-      scale_y_log10() + 
-      labs(x="",y = paste0("log[10]  ",col_name," + 0.01")) + 
-      theme_bw()
+    # plot the spatial variation
+    attr_plot_spatial <- dat_subset %>% 
+      left_join(.,network_geometry[,c("subsegid","geometry")],by=c("PRMS_segid"="subsegid")) %>%
+      sf::st_as_sf() %>%
+      ggplot() + 
+      geom_sf(aes(color=.data[[col_name]])) + 
+      scale_color_viridis_c(option="plasma") + 
+      theme_bw() + 
+      theme(plot.margin = unit(c(0,0,0,2), "cm"),
+            axis.text.x = element_text(size = 6),
+            legend.title = element_text(size = 10))
     
-    attr_plot_combined <- attr_plot + attr_plot_log + patchwork::plot_layout(ncol=2)
-    
+    # create combined plot showing violin plot and spatial distribution
+    attr_plot_combined <- attr_plot + attr_plot_spatial + patchwork::plot_layout(ncol=2)
+
     plot_name <- paste0(file_path,"/",col_name,".png")
     plot_names <- c(plot_names,plot_name)
     
     suppressWarnings(ggsave(plot_name,plot = attr_plot_combined,width=7,height=4,device = "png"))
     
   }
-  
-  plot_names <- plot_names[-1]
   
   return(plot_names)
   

--- a/3_visualize/src/summarize_nhdv2_attr.R
+++ b/3_visualize/src/summarize_nhdv2_attr.R
@@ -1,0 +1,33 @@
+summarize_nhdv2_attr <- function(attr_data,fileout){
+  #' 
+  #' @description This function summarizes each of the downloaded NHDv2 attribute variables across all river segments within the network
+  #'
+  #' @param attr_data list containing the processed NHDv2 attribute data; data frames must include column "PRMS_segid" 
+  #' @param fileout a character string that indicates the name of the output file, including path and extension
+  #'
+  #' @value Returns a csv file containing summary statistics for each NHDv2 attribute variable
+  
+  # Bind all columns representing unique NHDv2 attribute variables
+  attr_data_df <- attr_data %>%
+    Reduce(full_join,.) %>%
+    # hide messages that data frames are being joined by column 'PRMS_segid'
+    suppressMessages()
+  
+  # Define function to summarize the number of NA's in numeric vector x
+  num_NA <- function(x){
+    sum(is.na(x))
+  }
+  
+  # Calculate summary statistics for each variable's time series
+  attr_summary <- attr_data_df %>%
+    select(where(is.numeric)) %>%
+    pivot_longer(everything()) %>%
+    group_by(name) %>%
+    summarise_at(vars(value), list(Min = min, Mean = mean, Max = max, Sd = sd, num_NA = num_NA))
+  
+  # Save data summary
+  readr::write_csv(attr_summary,fileout)
+  
+  return(fileout) 
+  
+}

--- a/3_visualize/src/summarize_nhdv2_attr.R
+++ b/3_visualize/src/summarize_nhdv2_attr.R
@@ -23,7 +23,8 @@ summarize_nhdv2_attr <- function(attr_data,fileout){
     select(where(is.numeric)) %>%
     pivot_longer(everything()) %>%
     group_by(name) %>%
-    summarise_at(vars(value), list(Min = min, Mean = mean, Max = max, Sd = sd, num_NA = num_NA))
+    summarise_at(vars(value), list(Min = min, Mean = mean, Max = max, Sd = sd, num_NA = num_NA)) %>%
+    mutate_if(is.numeric, round, 3)
   
   # Save data summary
   readr::write_csv(attr_summary,fileout)

--- a/_targets.R
+++ b/_targets.R
@@ -4,7 +4,8 @@ options(tidyverse.quiet = TRUE)
 tar_option_set(packages = c("tidyverse", "lubridate",
                             "rmarkdown","dataRetrieval",
                             "knitr","leaflet","sf",
-                            'purrr', 'sbtools', 'terra')) 
+                            'purrr', 'sbtools', 'terra',
+                            'patchwork')) 
 
 source("1_fetch.R")
 source("2_process.R")
@@ -16,6 +17,7 @@ dir.create("3_visualize/out/", showWarnings = FALSE)
 dir.create("3_visualize/log/", showWarnings = FALSE)
 dir.create("3_visualize/out/daily_timeseries_png/",showWarnings = FALSE)
 dir.create("3_visualize/out/hourly_timeseries_png/",showWarnings = FALSE)
+dir.create("3_visualize/out/nhdv2_attr_png/",showWarnings = FALSE)
 
 # Define columns of interest for harmonized WQP data
 wqp_vars_select <- c("MonitoringLocationIdentifier","MonitoringLocationName","LongitudeMeasure","LatitudeMeasure",


### PR DESCRIPTION
Addresses #85.

The goal of this PR is to gather the downloaded NHDv2 attributes referenced to the upstream watershed (i.e., TOT/ACC) and build the target `p2_nhdv2_attr_upstream`. Upstream watershed attributes are joined to our PRMS segments using the COMID at the downstream end of the PRMS segment (`comid_down` from the xwalk table). There is minimal processing for these TOT or ACC attributes, but the following steps are applied in `process_cumulative_nhdv2_attr()`:

- process the PPT data to return long-term (1971-2000) monthly averages
- look for undesired flag values in the downloaded data (e.g. -9999) and replace with NA

To make it easier to inspect each of the attribute variables, this PR also adds two steps to plot the distribution of each NHDv2 attribute and to save a summary table that describes the variability of each attribute variable across the PRMS network:

![TOT_BFI](https://user-images.githubusercontent.com/8785034/155153385-366e4f6b-c879-45e1-aba6-5623a1bfc9d8.png)

```
> head(nhdv2_attr_summary)
# A tibble: 6 x 6
  name              Min     Mean      Max        Sd num_NA
  <chr>           <dbl>    <dbl>    <dbl>     <dbl>  <dbl>
1 TOT_ARTIFICIAL   0       8.52     50.0     6.99        0
2 TOT_AWCAVE       0.06    0.116     0.2     0.0168      0
3 TOT_BASIN_AREA   0.5  2614.    30744.   6516.          0
4 TOT_BASIN_SLOPE  0.16    9.01     26.7     6.01        0
5 TOT_BDAVE        1.22    1.41      1.56    0.0373      0
6 TOT_BEDPERM_1    0      54.0     100      42.5         0
```

Are these plots/summaries helpful to us? I envision the plots/summaries will ultimately be generated by calling the combined target that includes the upstream-level and the catchment-level attributes (topic of the next PR).  
 