### PR TITLE
Forcing dependencies in log files

### DIFF
--- a/3_visualize.R
+++ b/3_visualize.R
@@ -43,7 +43,12 @@ p3_targets_list <- list(
   # Create and save indicator file for WQP data
   tar_target(
     p3_wqp_ind_csv,
-    command = save_target_ind_files("3_visualize/log/wqp_data_ind.csv","p2_wqp_SC_csv"),
+    command = {
+      #forcing dependency to the target because the character string 
+      #of the target name does not enforce it
+      force_dep <- p2_wqp_SC_data
+      save_target_ind_files("3_visualize/log/wqp_data_ind.csv", "p2_wqp_SC_data")
+      },
     format = "file"),
   
   # Create and save summary log file for NWIS daily data

--- a/3_visualize/log/wqp_data_ind.csv
+++ b/3_visualize/log/wqp_data_ind.csv
@@ -1,1 +1,2 @@
-tar_name,hash
+tar_name,filepath,hash
+p2_wqp_SC_data,NA,b3db5d23f7e0ac37


### PR DESCRIPTION
It seems like our repo only had one log file that did not already have a target dependency: `p3_wqp_ind_csv`. For that target, the previous target name was `p2_wqp_SC_csv`, which was not a target name in our pipeline. I changed it to `p2_wqp_SC_data`.

Closes #91 