### PR TITLE
Update all old catchments sf targets with new edited catchments sf

### DIFF
--- a/1_fetch.R
+++ b/1_fetch.R
@@ -103,28 +103,6 @@ p1_targets_list <- list(
     get_nhdv2_flowlines(drb_huc8s)
   ),  
   
-  # Download PRMS catchments for region 02
-  ## Downloaded from ScienceBase: https://www.sciencebase.gov/catalog/item/5362b683e4b0c409c6289bf6
-  tar_target(
-    p1_catchments_shp,
-    get_gf(out_dir = "1_fetch/out/", sb_id = '5362b683e4b0c409c6289bf6', sb_name = gf_data_select),
-    format = "file"
-  ),
-  
-  # Read PRMS catchment shapefile into sf object and filter to DRB
-  tar_target(
-    p1_catchments_sf,
-    sf::st_read(dsn = p1_catchments_shp,layer="nhru", quiet=TRUE) %>%
-        filter(hru_segment %in% p1_reaches_sf$subsegseg) %>%
-        suppressWarnings() 
-  ),
-  
-  ## Fix issue geometries in p1_catchments_sf by defining a 0 buffer around polylines
-  tar_target(
-    p1_catchments_sf_valid, 
-    sf::st_buffer(p1_catchments_sf,0)
-  ),
-  
   # Download edited HRU polygons from https://github.com/USGS-R/drb-network-prep
   tar_target(
     p1_catchments_edited_gpkg,

--- a/2_process.R
+++ b/2_process.R
@@ -183,6 +183,7 @@ p2_targets_list <- list(
                                               sep = ',',
                                               pivot_longer_contains = 'lcClass') %>% 
                        # See documentation in function
+                     ## group by with both hru and prms because we need hru_segment to run the recursive function for upstream catchments
                      aggregate_proportions_hrus(group_by_segment_colname = vars(PRMS_segid,hru_segment),
                                                 proportion_col_prefix = 'prop_lcClass',
                                                 hru_area_colname = hru_area_m2,
@@ -197,6 +198,7 @@ p2_targets_list <- list(
   tar_target(
     p2_prms_attribute_df, 
     p1_prms_reach_attr %>% select(subseg_id,subseg_seg,from_segs,to_seg) %>% 
+      # renaming so that we can distinguish from p2_FORESCE_LC_per_catchment_reclass_cat$PRMS_segid col
       rename(.,PRMS_segid_main = subseg_id) %>% 
       # Update `from_segs` col by splitting the individual segs in a list (can then loop through the list) 
       mutate(from_segs = stringr::str_split(string = from_segs, pattern = ';', simplify = F)) %>% 

--- a/2_process.R
+++ b/2_process.R
@@ -199,7 +199,7 @@ p2_targets_list <- list(
     p2_prms_attribute_df, 
     p1_prms_reach_attr %>% select(subseg_id,subseg_seg,from_segs,to_seg) %>% 
       # renaming so that we can distinguish from p2_FORESCE_LC_per_catchment_reclass_cat$PRMS_segid col
-      rename(.,PRMS_segid_main = subseg_id) %>% 
+      rename(., PRMS_segid_main = subseg_id) %>% 
       # Update `from_segs` col by splitting the individual segs in a list (can then loop through the list) 
       mutate(from_segs = stringr::str_split(string = from_segs, pattern = ';', simplify = F)) %>% 
       rowwise() %>%
@@ -224,7 +224,8 @@ p2_targets_list <- list(
           # get proportions for the new total area
           across(starts_with('prop'), ~(sum((.x*total_PRMS_area)/total_upstream_PRMS_area))),
           .groups = 'drop_last') %>%
-        drop_na()
+        drop_na() %>% 
+        rename(., PRMS_segid = PRMS_segid_main)
       )}
   ),
   

--- a/2_process/src/FORESCE_agg_lc_props.R
+++ b/2_process/src/FORESCE_agg_lc_props.R
@@ -12,7 +12,7 @@ aggregate_proportions_hrus <- function(df, group_by_segment_colname, proportion_
     # Create temp cols of area of lc class per hru - NOTE: simply mutate current cols and no longer have proportion values
     mutate(across(starts_with(proportion_col_prefix),  ~(.x * {{hru_area_colname}})))%>% 
     # group by hru segments - droping from 761 row to 416 - to get a single "PRMS" catchment per PRMS segment
-    group_by({{group_by_segment_colname}}) %>%
+    group_by_at(group_by_segment_colname) %>%
     summarise(
       # calc total area of aggregated catchments
       total_area = sum({{hru_area_colname}}),

--- a/2_process/src/raster_to_catchment_polygons.R
+++ b/2_process/src/raster_to_catchment_polygons.R
@@ -40,8 +40,8 @@ raster_to_catchment_polygons <- function(polygon_sf, raster,
   #' @param raster_summary_fun for continuous raster, function to summarize the data by geometry. kept NULL if categorical_raster = TRUE
   #' @param new_raster_prefix prefix added to colnames to label raster classes/values
   #' @value A dataframe with the same columns as the polygon_sf spatial dataframe (except geometry col) with additional columns of the Land Cover classes
-  #' @example land cover raster ex: raster_to_catchment_polygons(polygon_sf = p1_catchments_sf_valid, raster = p1_FORESCE_backcasted_LC, categorical_raster = TRUE, new_cols_prefix = 'lc_)
-  #' @example cont. raster ex: raster_to_catchment_polygons(polygon_sf = p1_catchments_sf_valid, raster = p1_rod_salt, categorical_raster = FALSE, raster_summary_fun = sum, new_cols_prefix = 'cont_raster')
+  #' @example land cover raster ex: raster_to_catchment_polygons(polygon_sf = p1_catchments_edited_sf, raster = p1_FORESCE_backcasted_LC, categorical_raster = TRUE, new_cols_prefix = 'lc_)
+  #' @example cont. raster ex: raster_to_catchment_polygons(polygon_sf = p1_catchments_edited_sf, raster = p1_rod_salt, categorical_raster = FALSE, raster_summary_fun = sum, new_cols_prefix = 'cont_raster')
   
   # read in 
   raster <- rast(raster)

--- a/2_process/src/raster_to_catchment_polygons.R
+++ b/2_process/src/raster_to_catchment_polygons.R
@@ -74,7 +74,7 @@ raster_to_catchment_polygons <- function(polygon_sf, raster,
   message('extracting from categorical raster')
   ## Extract rasters pixels in each polygon
   start_time <- Sys.time()
-  raster_per_polygon <- terra::extract(raster_crop, vector, list = T) %>% 
+  raster_per_polygon <- terra::extract(raster_crop, vector, list = TRUE) %>% 
     #lapply(table) # to get frequency of each categorical value
     lapply(FUN = function(x) {table(x)/sum(table(x))})
   end_time <- Sys.time()

--- a/3_visualize/log/wqp_data_ind.csv
+++ b/3_visualize/log/wqp_data_ind.csv
@@ -1,2 +1,2 @@
 tar_name,filepath,hash
-p2_wqp_SC_data,NA,b3db5d23f7e0ac37
+p2_wqp_SC_data,NA,e00d1ba3df334493


### PR DESCRIPTION
Targets updated with new edited catchments sf: 

* `p2_rdsalt_per_catchment`
   Reviewed. The change to shapefile properly updates our rdsalt target. We now have rd_salt data for all 459 segments in drb, vs. 416 previously. 
Final rdsalt target `p2_rdsalt_per_catchment_allyrs`, that describes proportion of total (across all measured years) rdsalt accumulated in the catchment over the entire basin 
```
dim(p2_rdsalt_per_catchment_allyrs)
[1] 459   3
```

* `p2_FORESCE_LC_per_catchment`
 Reviewed. The change to the shapefile properly updates our `p2_FORESCE_LC_per_catchment` target. When the land cover target is reclassed `p2_FORESCE_LC_per_catchment_cat`, we now have FORESCE proportions for all 459 segments. 
 ```
  dim(p2_FORESCE_LC_per_catchment_reclass_cat[[1]]) # item 1 in this target list is first FORESCE model lc year queried : 1940 
[1] 459  14
```

* Block:

Issue with target `p2_FORESCE_LC_per_catchment_tot` that follows `p2_FORESCE_LC_per_catchment_cat`. See Issue #126 for details. 
