### PR TITLE
124 synoptic sites

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ _targets
 #Other local files
 archive/*
 1_fetch/in/NLCDs_2001_2019/*
+1_fetch/in/DRB_2021_synoptic_sites_by_transect_20210819.xlsx
 
 #R files
 # History files

--- a/1_fetch.R
+++ b/1_fetch.R
@@ -314,8 +314,15 @@ p1_targets_list <- list(
   # Rename columns to match needs of site to reach function
   tar_target(
     p1_syn_sites,
-    readxl::read_xlsx(syn_file, sheet = 'Clean_NtoS') %>%
-      rename(site_id = site_no, lat = dec_lat_va, lon = dec_long_va)
+    {
+      if(!('DRB_2021_synoptic_sites_by_transect_20210819.xlsx' %in% 
+           list.files('1_fetch/in/'))){
+        stop('Please add DRB_2021_synoptic_sites_by_transect_20210819.xlsx to 1_fetch/in')
+      }
+      readxl::read_xlsx('1_fetch/in/DRB_2021_synoptic_sites_by_transect_20210819.xlsx', 
+                        sheet = 'Clean_NtoS') %>%
+        rename(site_id = site_no, lat = dec_lat_va, lon = dec_long_va)
+    }
   )
 )
   

--- a/1_fetch.R
+++ b/1_fetch.R
@@ -308,6 +308,18 @@ p1_targets_list <- list(
      file.path(dirname(p1_natural_baseflow_zip), list.files(path = dirname(p1_natural_baseflow_zip),pattern = "*baseflow.*.csv"))
       },
     format = "file"
+  ),
+  
+  # Load synoptic sampling sites
+  tar_target(
+    p1_syn_sites,
+    readxl::read_xlsx(syn_file, sheet = 'Clean_NtoS')
+  ),
+  # Create spatial dataframe
+  tar_target(
+    p1_syn_sites_sf,
+    st_as_sf(test, coords = c('dec_lat_va', 'dec_long_va')) %>%
+      st_set_crs(value = '4269')
   )
 )
   

--- a/1_fetch.R
+++ b/1_fetch.R
@@ -310,16 +310,12 @@ p1_targets_list <- list(
     format = "file"
   ),
   
-  # Load synoptic sampling sites
+  # Load synoptic sampling sites.
+  # Rename columns to match needs of site to reach function
   tar_target(
     p1_syn_sites,
-    readxl::read_xlsx(syn_file, sheet = 'Clean_NtoS')
-  ),
-  # Create spatial dataframe
-  tar_target(
-    p1_syn_sites_sf,
-    st_as_sf(test, coords = c('dec_lat_va', 'dec_long_va')) %>%
-      st_set_crs(value = '4269')
+    readxl::read_xlsx(syn_file, sheet = 'Clean_NtoS') %>%
+      rename(site_id = site_no, lat = dec_lat_va, lon = dec_long_va)
   )
 )
   

--- a/2_process.R
+++ b/2_process.R
@@ -331,6 +331,14 @@ p2_targets_list <- list(
   tar_target(
     p2_nhdv2_attr,
     create_nhdv2_attr_table(p2_nhdv2_attr_upstream,p2_nhdv2_attr_catchment)
+  ),
+  
+  # Match PRMS stream segments to synoptic site ids and return subset of sites within 
+  # the distance specified by search_radius (in meters)
+  tar_target(
+    p2_syn_sites_w_segs,
+    get_site_flowlines(p1_reaches_sf, p1_syn_sites, sites_crs = 4269, max_matches = 1, 
+                       search_radius = bird_dist_cutoff_m, retain_sites = NULL)
   )
 )
 

--- a/3_visualize.R
+++ b/3_visualize.R
@@ -76,6 +76,17 @@ p3_targets_list <- list(
                     file_path = "3_visualize/out/nhdv2_attr_png"),
     format = "file"
   ),
+  # with synoptic sampling sites
+  tar_target(
+    p3_nhdv2_attr_syn_sites_png,
+    plot_nhdv2_attr(attr_data = p2_nhdv2_attr,
+                    network_geometry = p1_reaches_sf,
+                    file_path = "3_visualize/out/nhdv2_attr_png/synoptic",
+                    plot_sites = TRUE, 
+                    sites = p2_syn_sites_w_segs, 
+                    sites_crs = 4269),
+    format = "file"
+  ),
   
   # Create and save a summary table that describes variation in the NHDv2 attribute variables across the PRMS network
   tar_target(

--- a/3_visualize/src/plot_nhdv2_attr.R
+++ b/3_visualize/src/plot_nhdv2_attr.R
@@ -1,4 +1,5 @@
-plot_nhdv2_attr <- function(attr_data,network_geometry,file_path){
+plot_nhdv2_attr <- function(attr_data,network_geometry,file_path,
+                            plot_sites = FALSE, sites = NULL, sites_crs = NULL){
   #' 
   #' @description This function visualizes each of the downloaded NHDv2 attribute variables across all river segments within the network
   #'
@@ -7,8 +8,28 @@ plot_nhdv2_attr <- function(attr_data,network_geometry,file_path){
   #' @param network_geometry sf object containing the network flowline geometry; 
   #' must include columns "subsegid" and "geometry"
   #' @param file_path a character string that indicates the location of the saved plot
+  #' @param plot_sites logical indicating whether or not to plot SC sampling sites
+  #' @param sites tbl with the SC sampling sites and columns for the corresponding PRMS 'subsegid'
+  #' @param sites_crs the crs of the sites table (i.e., 4269 for NAD83)
   #'
   #' @value Returns a png file containing a violin plot showing distribution of each NHDv2 attribute variable
+
+  if (plot_sites){
+    if (is.null(sites)){
+      stop('sites must be specified when plot_sites = TRUE')
+    }
+    if (is.null(sites_crs)){
+      stop('sites CRS must be specified when plot_sites = TRUE')
+    }
+    # Create spatial dataframe
+    sites <- st_as_sf(sites, coords = c('lon', 'lat')) %>%
+      st_set_crs(value = sites_crs)
+    
+    #add indicator to attr_data for reaches that have sites
+    attr_data_ind <- mutate(attr_data, 
+                        site_reaches = case_when(PRMS_segid %in% sites$subsegid ~ 1,
+                                                 TRUE ~ 0))
+  }
   
   message("Plotting individual NHDv2 attribute variables")
   
@@ -16,30 +37,58 @@ plot_nhdv2_attr <- function(attr_data,network_geometry,file_path){
   
   # For each column/attribute variable, plot the distribution of the data across all PRMS segments
   for(i in 2:dim(attr_data)[2]){
-    
-    dat_subset <- attr_data[,c(1,i)]
-    col_name <- names(dat_subset)[2]
-    
-    # plot the distribution of attr values on a linear scale
-    attr_plot <- dat_subset %>%
-      ggplot(aes(x = "", y = .data[[col_name]])) + 
-      geom_violin(draw_quantiles = c(0.5)) +
-      geom_jitter(height=0,color = "steelblue",alpha=0.5,width=0.2) +
-      labs(x="") + 
-      theme_bw() + 
-      theme(plot.margin = unit(c(0,0,0,0), "cm"))
-    
-    # plot the spatial variation
-    attr_plot_spatial <- dat_subset %>% 
-      left_join(.,network_geometry[,c("subsegid","geometry")],by=c("PRMS_segid"="subsegid")) %>%
-      sf::st_as_sf() %>%
-      ggplot() + 
-      geom_sf(aes(color=.data[[col_name]]), size = 0.3) + 
-      scale_color_viridis_c(option="plasma") + 
-      theme_bw() + 
-      theme(plot.margin = unit(c(0,0,0,2), "cm"),
-            axis.text.x = element_text(size = 6),
-            legend.title = element_text(size = 10))
+    if(plot_sites){
+      dat_subset <- attr_data_ind[,c(1,i,ncol(attr_data_ind))]
+      col_name <- names(dat_subset)[2]
+      
+      # plot the distribution of attr values on a linear scale
+      attr_plot <- dat_subset %>%
+        ggplot(aes(x = "", y = .data[[col_name]])) + 
+        geom_violin(draw_quantiles = c(0.5)) +
+        geom_jitter(height=0, color = case_when(dat_subset$site_reaches == 1 ~ "red", 
+                                                TRUE ~ "steelblue"),
+                    alpha=0.5,width=0.2) +
+        labs(x="") + 
+        theme_bw() + 
+        theme(plot.margin = unit(c(0,0,0,0), "cm"))
+      
+      # plot the spatial variation
+      attr_plot_spatial <- dat_subset %>% 
+        left_join(.,network_geometry[,c("subsegid","geometry")],by=c("PRMS_segid"="subsegid")) %>%
+        sf::st_as_sf() %>%
+        ggplot() + 
+        geom_sf(aes(color=.data[[col_name]]), size = 0.3) + 
+        scale_color_viridis_c(option="plasma") + 
+        theme_bw() + 
+        theme(plot.margin = unit(c(0,0,0,2), "cm"),
+              axis.text.x = element_text(size = 6),
+              legend.title = element_text(size = 10)) +
+        geom_sf(data = sites, size = 0.3)
+    }else{
+      dat_subset <- attr_data[,c(1,i)]
+      col_name <- names(dat_subset)[2]
+      
+      # plot the distribution of attr values on a linear scale
+      attr_plot <- dat_subset %>%
+        ggplot(aes(x = "", y = .data[[col_name]])) + 
+        geom_violin(draw_quantiles = c(0.5)) +
+        geom_jitter(height=0,color = "steelblue",alpha=0.5,width=0.2) +
+        labs(x="") + 
+        theme_bw() + 
+        theme(plot.margin = unit(c(0,0,0,0), "cm"))
+      
+      # plot the spatial variation
+      attr_plot_spatial <- dat_subset %>% 
+        left_join(.,network_geometry[,c("subsegid","geometry")],by=c("PRMS_segid"="subsegid")) %>%
+        sf::st_as_sf() %>%
+        ggplot() + 
+        geom_sf(aes(color=.data[[col_name]]), size = 0.3) + 
+        scale_color_viridis_c(option="plasma") + 
+        theme_bw() + 
+        theme(plot.margin = unit(c(0,0,0,2), "cm"),
+              axis.text.x = element_text(size = 6),
+              legend.title = element_text(size = 10))
+    }
     
     # create combined plot showing violin plot and spatial distribution
     attr_plot_combined <- attr_plot + attr_plot_spatial + patchwork::plot_layout(ncol=2)

--- a/_targets.R
+++ b/_targets.R
@@ -119,9 +119,6 @@ NADP_sb_id <- '57e2ac2fe4b0908250045981'
 ## FORESCE list of FORESCE years
 FORESCE_years <- c('1940', '1950', '1960', '1970', '1980', '1990', '2000')
 
-## Path to synoptic sampling sites
-syn_file <- 'C:/Users/jsmith/OneDrive - DOI/Shared Documents - GS-WMA-IWP-PUMP/40.2 Data-driven salinity/Data/DRB-Inland/DRB_2021_synoptic_sites_by_transect_20210819.xlsx'
-
 # Return the complete list of targets
 c(p1_targets_list, p2_targets_list, p3_targets_list)
 

--- a/_targets.R
+++ b/_targets.R
@@ -5,7 +5,7 @@ tar_option_set(packages = c("tidyverse", "lubridate",
                             "rmarkdown","dataRetrieval",
                             "knitr","leaflet","sf",
                             "purrr", "sbtools", "terra",
-                            "patchwork", "glue")) 
+                            "patchwork", "glue", "readxl")) 
 
 source("1_fetch.R")
 source("2_process.R")
@@ -18,6 +18,7 @@ dir.create("3_visualize/log/", showWarnings = FALSE)
 dir.create("3_visualize/out/daily_timeseries_png/",showWarnings = FALSE)
 dir.create("3_visualize/out/hourly_timeseries_png/",showWarnings = FALSE)
 dir.create("3_visualize/out/nhdv2_attr_png/",showWarnings = FALSE)
+dir.create("3_visualize/out/nhdv2_attr_png/synoptic",showWarnings = FALSE)
 
 # Define columns of interest for harmonized WQP data
 wqp_vars_select <- c("MonitoringLocationIdentifier","MonitoringLocationName","LongitudeMeasure","LatitudeMeasure",
@@ -117,6 +118,9 @@ NADP_sb_id <- '57e2ac2fe4b0908250045981'
 
 ## FORESCE list of FORESCE years
 FORESCE_years <- c('1940', '1950', '1960', '1970', '1980', '1990', '2000')
+
+## Path to synoptic sampling sites
+syn_file <- 'C:/Users/jsmith/OneDrive - DOI/Shared Documents - GS-WMA-IWP-PUMP/40.2 Data-driven salinity/Data/DRB-Inland/DRB_2021_synoptic_sites_by_transect_20210819.xlsx'
 
 # Return the complete list of targets
 c(p1_targets_list, p2_targets_list, p3_targets_list)


### PR DESCRIPTION
This PR adds synoptic sampling sites as a target, finds their nearest PRMS segment, and visualizes their static attributes. 

Most of these sites are within 50 m of the PRMS segment to which it is matched:
![image](https://user-images.githubusercontent.com/8761242/159536845-9bc6b817-3ead-48d0-a83c-516fb2353384.png)

For most attributes, these sites cover the range in attribute values. It might be helpful to sample some more urban reaches around Philadelphia (yellow/orange in figure below).

Example for total road density. Open to viz suggestions.
![TOT_TOTAL_ROAD_DENS](https://user-images.githubusercontent.com/8761242/159533842-2c0dd3be-2110-4a53-8c3b-b5f79b5dff99.png)


- [ ] It might be worth waiting to merge this PR until after a land cover viz has been added to our pipeline. I know Doug was interested in seeing the land cover attributes that these sites sample.

This PR will merge in to a new branch on USGS-R
Closes #124 