### PR TITLE
Ignore folders that are added when running Docker in the repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,9 @@ _targets
 #Other local files
 archive/*
 1_fetch/in/NLCDs_2001_2019/*
+rstudio
+.config
+.local
 
 #R files
 # History files

--- a/.gitignore
+++ b/.gitignore
@@ -7,9 +7,9 @@ _targets
 #Other local files
 archive/*
 1_fetch/in/NLCDs_2001_2019/*
-rstudio
+rstudio*
 .config
-.local
+.local*
 
 #R files
 # History files


### PR DESCRIPTION
This PR adds 3 folder names to the .gitignore file. These appear when RStudio is run in the browser using Docker.

Closes #113 