### PR TITLE
41 aggr time series

### DIFF
--- a/2_process.R
+++ b/2_process.R
@@ -9,6 +9,7 @@ source('2_process/src/reclassify_land_cover.R')
 source('2_process/src/FORESCE_agg_lc_props.R')
 source("2_process/src/process_nhdv2_attr.R")
 source("2_process/src/recursive_fun.R")
+source("2_process/src/aggregate_observations.R")
 
 
 p2_targets_list <- list(
@@ -269,6 +270,13 @@ p2_targets_list <- list(
     create_site_list_nontidal(p2_wqp_SC_filtered,p1_nwis_sites,p1_daily_data,p1_inst_data,
                               hucs=drb_huc8s,crs_out="NAD83",p2_sites_w_segs,"2_process/out/DRB_SC_sitelist_nontidal.csv"),
     format = "file"
+  ),
+  
+  # Return SC observations aggregated to the PRMS segment
+  tar_target(
+    p2_SC_observations,
+    aggregate_observations(p2_wqp_SC_filtered, p2_daily_combined, p2_sites_w_segs, 
+                           aggr_method = "reach", prefer_nwis_sites = FALSE)
   ),
   
   # Return natural baseflow estimates for each PRMS segment

--- a/2_process/src/aggregate_observations.R
+++ b/2_process/src/aggregate_observations.R
@@ -1,0 +1,150 @@
+combine_wq_data <- function(wqp_data, nwis_data){
+  #' 
+  #' @description Function to combine WQP datasets with NWIS daily data
+  #' 
+  #' @param wqp_data data frame containing discrete water quality data 
+  #' from the wQP. Must contain cols MonitoringLocationIdentifier, 
+  #' OrganizationIdentifier, ActivityStartDate, resultVal2, 
+  #' ResultStatusIdentifier
+  #' @param nwis_data data frame containing combined instantaneous (uv)
+  #' and daily (dv) data; expected cols are agency_cd, site_no, Date, 
+  #' Parameter, Value, Value_cd, Value_Max, Value_Max_cd, Value_Min,
+  #' Value_Min_cd, dat_src
+  #' 
+  #' @value returns a data frame containing discrete and continuous 
+  #' water quality observations
+  #' 
+  
+  # Reformat WQP data to match NWIS datasets
+  wqp_data_formatted <- wqp_data %>%
+    # format site names for NWIS sites with prefix "USGS"
+    mutate(site_id = if_else(grepl('USGS',MonitoringLocationIdentifier),
+                             substr(MonitoringLocationIdentifier, 6, 100),
+                             MonitoringLocationIdentifier),
+           Parameter = "SpecCond") %>%
+    # harmonize column names with cols used in nwis_data
+    rename(agency_cd = OrganizationIdentifier,
+           site_no = site_id,
+           Date = ActivityStartDate) %>%
+    # find the min/max and the mean (if multiple observations exist 
+    # for a unique site-date)
+    group_by(site_no, Date, agency_cd, Parameter) %>%
+    summarize(Value = round(mean(resultVal2, na.rm = TRUE), 1),
+              Value_cd = unique(ResultStatusIdentifier),
+              Value_Max = max(resultVal2, na.rm = TRUE),
+              Value_Max_cd = NA_character_,
+              Value_Min = min(resultVal2, na.rm = TRUE),
+              Value_Min_cd = NA_character_,
+              .groups = "keep") %>%
+    ungroup() %>%
+    # pare down columns of interest and specify the data source
+    select(agency_cd, site_no, Date, Parameter, Value, Value_cd, 
+           Value_Max, Value_Max_cd, Value_Min, Value_Min_cd) %>%
+    mutate(dat_src = "WQP")
+  
+  # Combine wqp_data and nwis_data into a single data frame
+  nwis_data$dat_src <- "NWIS"
+  
+  combined_data <- bind_rows(wqp_data_formatted, nwis_data)
+  
+  return(combined_data) 
+  
+}
+
+
+
+aggregate_observations <- function(wqp_data, nwis_data, sites_w_segs, 
+                                   aggr_method = "reach", prefer_nwis_sites = FALSE){
+  #' 
+  #' @description Function to aggregate water quality observations to 1 value/day
+  #'
+  #' @param wqp_data data frame containing discrete water quality data from the wQP. 
+  #' Must contain cols MonitoringLocationIdentifier, OrganizationIdentifier, 
+  #' ActivityStartDate, resultVal2, ResultStatusIdentifier
+  #' @param nwis_data data frame containing combined instantaneous (uv) and daily (dv) data; 
+  #' expected cols are agency_cd, site_no, Date, Parameter, Value, Value_cd, Value_Max, 
+  #' Value_Max_cd, Value_Min, Value_Min_cd, dat_src
+  #' @param sites_w_segs data frame containing site locations and matched segment id's;
+  #' must contain column site_id
+  #' @param aggr_method character vector indicating how observations should be aggregated;
+  #' options include "reach" and "site" (defaults to "reach"). If "reach", then values 
+  #' returned represent 1 value/segment/day, if "site", then values will be returned for
+  #' each lat/lon location (maintaining multiple sites along a segment) amounting to 
+  #' 1 value/site/day
+  #' @param prefer_nwis_sites logical, only applies when aggr_method = "reach"; indicates
+  #' whether segment summaries should defer to NWIS observations when available. Defaults 
+  #' to FALSE. If TRUE, any observations coming from a non-NWIS site will be omitted.
+  #' 
+  #' @value returns a data frame containing 1 mean/min/max value for each unique segment-date
+  #' 
+  
+  # Format water quality data to include segment assignments
+  vars <- c("site_id", "lon", "lat", "datum", "subsegid",
+            "bird_dist_to_subseg_m", "segidnat")
+  sites_w_segs <- sites_w_segs %>%
+    select(any_of(vars))
+  
+  obs_data_w_segs <- combine_wq_data(wqp_data, nwis_data) %>%
+    filter(site_no %in% sites_w_segs$site_id) %>%
+    left_join(.,sites_w_segs,
+              by=c("site_no" = "site_id")) 
+  
+  # Aggregate observations 
+  if(aggr_method == "reach"){
+    
+    obs_data_aggr <- obs_data_w_segs %>%
+      group_by(subsegid, Date) %>%
+      # If prefer_nwis_sites = TRUE, check whether data for that segment comes from
+      # multiple sources (i.e., WQP and NWIS). If multiple sources, filter out any
+      # non-NWIS samples for that segment-date; otherwise, retain all samples
+      {if(prefer_nwis_sites == "TRUE"){
+        filter(.,if(n_distinct(dat_src) > 1) dat_src == "NWIS" else TRUE)
+      } else {.}
+      } %>%
+      summarize(mean_value = round(mean(Value, na.rm = TRUE), 1),
+                min_value = min(c(mean_value,Value_Min), na.rm = TRUE),
+                max_value = max(c(mean_value,Value_Max), na.rm = TRUE),
+                sd_value = round(sd(Value, na.rm = TRUE), 2),
+                n_value = length(!is.na(Value)),
+                site_ids = paste0(unique(site_no), collapse = ","),
+                .groups = "keep") %>%
+      # suppress any warnings related to taking min/max summaries
+      # when no non-NA data exist for a reach-date; in these cases, 
+      # Inf will be returned for min_value, max_value
+      suppressWarnings() %>%
+      mutate(cv_value = (sd_value/mean_value)) %>%
+      ungroup()
+    
+  } else {
+    
+    # For aggr_method = "site", group by lat/lon since in the WQP database, there
+    # may exist different site names that share the same geographic coordinates
+    obs_data_aggr <- obs_data_w_segs %>%
+      group_by(lat,lon,Date) %>%
+      summarize(mean_value = round(mean(Value, na.rm = TRUE), 1),
+                min_value = min(c(mean_value,Value_Min), na.rm = TRUE),
+                max_value = max(c(mean_value,Value_Max), na.rm = TRUE),
+                sd_value = round(sd(Value, na.rm = TRUE), 2),
+                n_value = length(!is.na(Value)),
+                site_ids = paste0(unique(site_no), collapse = ","),
+                .groups = "keep") %>%
+      # suppress any warnings related to taking min/max summaries
+      # when no non-NA data exist for a reach-date; in these cases, 
+      # Inf will be returned for min_value, max_value
+      suppressWarnings() %>%
+      mutate(cv_value = (sd_value/mean_value)) %>%
+      ungroup()
+    
+  }
+  
+  # Format aggregated data and replace any values of Inf with NA
+  vars_to_keep <- c("subsegid","lat","lon","Date","mean_value","min_value",
+                    "max_value","n_value","sd_value","cv_value","site_ids")
+  obs_data_aggr_out <- obs_data_aggr %>%
+    select(any_of(vars_to_keep)) %>%
+    mutate(across(where(is.numeric), ~na_if(., "Inf"))) 
+  
+  return(obs_data_aggr_out)
+  
+}
+

--- a/2_process/src/aggregate_observations.R
+++ b/2_process/src/aggregate_observations.R
@@ -70,7 +70,10 @@ aggregate_observations <- function(wqp_data, nwis_data, sites_w_segs,
   #' options include "reach" and "site" (defaults to "reach"). If "reach", then values 
   #' returned represent 1 value/segment/day, if "site", then values will be returned for
   #' each lat/lon location (maintaining multiple sites along a segment) amounting to 
-  #' 1 value/site/day
+  #' 1 value/site/day. Aggregating by "site" can be useful if a user wishes to keep 
+  #' unaggregated, raw data matched to segments. With the "site" option, sites are aggregated 
+  #' by geographic location because occasionally there are multiple site names that have 
+  #' the same lat/lon location.
   #' @param prefer_nwis_sites logical, only applies when aggr_method = "reach"; indicates
   #' whether segment summaries should defer to NWIS observations when available. Defaults 
   #' to FALSE. If TRUE, any observations coming from a non-NWIS site will be omitted.


### PR DESCRIPTION
Addresses #41.

The code changes here create a new target `p2_SC_observations` that represents the daily specific conductance mean/min/max aggregated at the scale of a PRMS segment, or 1 value/segment/day. 

The `aggregate_observations()` function has an argument for `aggr_method` so that we can also retain the individual site locations if of interest (`aggr_method = "site"` will aggregate sites that may have different site id's but share geographic coordinates per the lat/lon values given). There is also an argument for `prefer_nwis_sites` that defaults to FALSE but allows us to preferentially retain and use the data from NWIS sites for reach-days where multiple data sources are available (e.g., WQP data and continuous data from NWIS).

Here's a preview of the new target:
```
> tar_load(p2_SC_observations)
> head(p2_SC_observations)
# A tibble: 6 x 9
  subsegid Date       mean_value min_value max_value n_value sd_value cv_value site_ids
  <chr>    <date>          <dbl>     <dbl>     <dbl>   <int>    <dbl>    <dbl> <chr>   
1 1_1      1985-06-13         53        53        53       1       NA       NA 01413085
2 1_1      1985-08-21         64        64        64       1       NA       NA 01413085
3 1_1      1985-12-03         51        51        51       1       NA       NA 01413085
4 1_1      1986-03-14         44        44        44       1       NA       NA 01413085
5 1_1      1986-05-19         52        52        52       1       NA       NA 01413085
6 1_1      1987-03-27         41        40        42       1       NA       NA 01413085
> 
```


