### PR TITLE
Fix pipeline warnings

### DIFF
--- a/2_process/src/match_sites_reaches.R
+++ b/2_process/src/match_sites_reaches.R
@@ -54,7 +54,7 @@ get_site_flowlines <- function(reach_sf, sites, sites_crs, max_matches = 1, sear
   flowline_indices <- nhdplusTools::get_flowline_index(flines = reaches_nhd_fields,
                                                        points = sites_sf,
                                                        max_matches = max_matches,
-                                                       search_radius = search_radius*2,
+                                                       search_radius = units::set_units(search_radius*2, "m"),
                                                        precision = 1) %>%
     select(COMID, id, offset) %>%
     rename(subsegid = COMID, bird_dist_to_subseg_m = offset) %>% 

--- a/2_process/src/match_sites_reaches.R
+++ b/2_process/src/match_sites_reaches.R
@@ -35,7 +35,7 @@ get_site_flowlines <- function(reach_sf, sites, sites_crs, max_matches = 1, sear
     st_transform(5070)
   
   sites_sf <- sites %>% rowwise() %>%
-    filter(across(c(lon, lat), ~ !is.na(.x))) %>%
+    filter(if_all(c(lon, lat), ~ !is.na(.x))) %>%
     mutate(Shape = list(st_point(c(lon, lat), dim = "XY"))) %>%
     st_as_sf() %>% st_set_crs(sites_crs) %>%
     st_transform(st_crs(reaches_nhd_fields)) %>%


### PR DESCRIPTION
This PR fixes 2 warnings:

1. search radius warning in `get_flowline_index`: Fixed by using `search_radius = units::set_units(search_radius*2, "m")` in the function call. I checked that it worked by loading in the old target as `test` and comparing the na locations and data values:
```
test <- tar_read(p2_sites_w_segs)
tar_make(p2_sites_w_segs)
tar_load(p2_sites_w_segs)
all(which(is.na(test), arr.ind = T) == which(is.na(p2_sites_w_segs), arr.ind = T))
[1] TRUE
all(test == p2_sites_w_segs, na.rm = T)
[1] TRUE
```
2. using across in filter: I changed to `if_all` for the one case we had of `across` in a `filter`. I tested that it worked using the same method as 1.  

Closes #144 