### PR TITLE
editing scientific notation options

### DIFF
--- a/3_visualize.R
+++ b/3_visualize.R
@@ -77,9 +77,10 @@ p3_targets_list <- list(
   # Create and save summary log file for NWIS daily data
   tar_target(
     p3_daily_timeseries_summary_csv,
-    command = target_summary_stats(p1_daily_data,
-                                   "Value",
-                                   "3_visualize/log/daily_timeseries_summary.csv"),
+    {options(scipen = 999)
+      target_summary_stats(p1_daily_data, "Value",
+                           "3_visualize/log/daily_timeseries_summary.csv")
+      options(scipen = 0)},
     format = "file",
     deployment = 'main'
   ),
@@ -87,9 +88,10 @@ p3_targets_list <- list(
   # Create and save summary log file for NWIS instantaneous data
   tar_target(
     p3_inst_timeseries_summary_csv,
-    command = target_summary_stats(p1_inst_data,
-                                   "Value_Inst",
-                                   "3_visualize/log/inst_timeseries_summary.csv"),
+    {options(scipen = 999)
+      target_summary_stats(p1_inst_data, "Value_Inst",
+                           "3_visualize/log/inst_timeseries_summary.csv")
+      options(scipen = 0)},
     format = "file",
     deployment = 'main'
   ),


### PR DESCRIPTION
Edits options to ensure that the site numbers do not write in scientific notation. Decided this was a simpler fix than changing the number to a character.

I did not run this yet because these targets are changed to be stored locally in #161.

Closes #155