### PR TITLE
Subset tidal reaches

### DIFF
--- a/2_process.R
+++ b/2_process.R
@@ -126,6 +126,17 @@ p2_targets_list <- list(
     p2_tidal_reaches,
     subset_tidal_reaches(p1_reaches_sf, p2_drb_comids_seg, tidal_elev_m = 4)
   ),
+  tar_target(
+    p2_tidal_reaches_txt,
+    {
+      reach_df = as.data.frame(p2_tidal_reaches)
+      colnames(reach_df) = 'PRMS_segid'
+      write_csv(reach_df, '2_process/out/p2_tidal_reaches.txt')
+      '2_process/out/p2_tidal_reaches.txt'
+    },
+    format = 'file',
+    repository = 'local'
+  ),
   
   #----
   # NLCD Land Cover Proportions 

--- a/2_process.R
+++ b/2_process.R
@@ -100,12 +100,27 @@ p2_targets_list <- list(
       rename(comid = comid_cat)
   ),
   
+  # Reshape PRMS-NHDv2 xwalk table to return all COMIDS that intersect/overlap the PRMS segments
+  tar_target(
+    p2_drb_comids_seg,
+    p2_prms_nhdv2_xwalk %>%
+      select(PRMS_segid, comid_seg) |> 
+      tidyr::separate_rows(comid_seg,sep=";") |> 
+      rename(comid = comid_seg)
+  ),
+  
   # Subset PRMS-NHDv2 xwalk table to return the COMID located at the downstream end of each PRMS segment
   tar_target(
     p2_drb_comids_down,
     p2_prms_nhdv2_xwalk %>% 
       select(PRMS_segid,comid_down) %>% 
       rename(comid = comid_down)
+  ),
+  
+  # Subset PRMS segments that may be tidally-influenced
+  tar_target(
+    p2_tidal_reaches_sf,
+    subset_tidal_reaches(p1_reaches_sf, p2_drb_comids_seg)
   ),
   
   #----

--- a/2_process.R
+++ b/2_process.R
@@ -120,7 +120,7 @@ p2_targets_list <- list(
   
   # Subset PRMS segments that may be tidally-influenced
   tar_target(
-    p2_tidal_reaches_sf,
+    p2_tidal_reaches,
     subset_tidal_reaches(p1_reaches_sf, p2_drb_comids_seg)
   ),
   

--- a/2_process.R
+++ b/2_process.R
@@ -13,6 +13,7 @@ source('2_process/src/area_diff_fix.R')
 source('2_process/src/clean_lulc_data_for_merge.R')
 source('2_process/src/add_dynamic_attr.R')
 source('2_process/src/write_data.R')
+source("2_process/src/subset_tidal_reaches.R")
 
 
 p2_targets_list <- list(

--- a/2_process.R
+++ b/2_process.R
@@ -129,10 +129,24 @@ p2_targets_list <- list(
   tar_target(
     p2_tidal_reaches_txt,
     {
+      fileout = '2_process/out/p2_tidal_reaches.txt'
       reach_df = as.data.frame(p2_tidal_reaches)
       colnames(reach_df) = 'PRMS_segid'
-      write_csv(reach_df, '2_process/out/p2_tidal_reaches.txt')
-      '2_process/out/p2_tidal_reaches.txt'
+      write_csv(reach_df, fileout)
+      fileout
+    },
+    format = 'file',
+    repository = 'local'
+  ),
+  tar_target(
+    p2_nontidal_reaches_txt,
+    {
+      fileout = '2_process/out/p2_nontidal_reaches.txt'
+      
+      nontidal = p1_reaches_sf$subsegid[!(p1_reaches_sf$subsegid %in% p2_tidal_reaches)]
+      reach_df = as.data.frame(nontidal)
+      write_csv(reach_df, fileout, col_names = FALSE)
+      fileout
     },
     format = 'file',
     repository = 'local'

--- a/2_process.R
+++ b/2_process.R
@@ -119,9 +119,12 @@ p2_targets_list <- list(
   ),
   
   # Subset PRMS segments that may be tidally-influenced
+  # Based on the elevation of tidally-influenced NWIS gages in the DRB, 4 meters
+  # is used to indicate the likely head-of-tide. 
+  # See https://github.com/USGS-R/drb-inland-salinity-ml/issues/241
   tar_target(
     p2_tidal_reaches,
-    subset_tidal_reaches(p1_reaches_sf, p2_drb_comids_seg)
+    subset_tidal_reaches(p1_reaches_sf, p2_drb_comids_seg, tidal_elev_m = 4)
   ),
   
   #----

--- a/2_process/src/subset_tidal_reaches.R
+++ b/2_process/src/subset_tidal_reaches.R
@@ -1,18 +1,33 @@
-subset_tidal_reaches <- function(reach_sf, segs_w_comids){
+subset_tidal_reaches <- function(reach_sf, segs_w_comids, tidal_elev_m = NULL){
   #' Subset tidally-influenced PRMS segments
   #' 
   #' @details
-  #' A PRMS segment may be tidal if at least one overlapping NHDPlusv2 COMID
-  #' is labeled as "tidal == 1" in NHDPlus.
+  #' A PRMS segment may be tidal if 1) at least one overlapping NHDPlusv2 COMID
+  #' is labeled as "tidal == 1" in NHDPlus, or 2) the "minelevsmo" and "maxelevsmo"
+  #' values from NHDPlus are both less than `tidal_elev_m`*100 for at least one 
+  #' overlapping NHDPlusv2 COMID. 
   #' 
   #' @param reach_sf sf object of reach polylines with column "subsegid"
   #' @param segs_w_comids data frame containing the PRMS segment ids and the 
   #' NHDPlusv2 COMIDs of interest. Must contain columns "PRMS_segid" and "comid"
+  #' @param tidal_elev_m optional; integer value indicating the cutoff elevation
+  #' used to indicate the head-of-tide. If NULL, the default value of 6 meters 
+  #' from NHDPlusv2 will be used to define the tidal extent. Defaults to NULL.
   #' 
-
+  
   # Download NHDv2 COMIDs that lie along NHM network, then subset "tidal" COMIDs 
   nhdv2_flines <- nhdplusTools::get_nhdplus(comid = segs_w_comids$comid, realization = "flowline")
-  comids_tidal <- nhdv2_flines$comid[nhdv2_flines$tidal == 1]
+  
+  if(is.null(tidal_elev_m)){
+    comids_tidal <- nhdv2_flines$comid[nhdv2_flines$tidal == 1]
+  } else {
+    # maxelevsmo and minelevsmo have units of centimeters
+    comids_tidal <- filter(nhdv2_flines, 
+                           maxelevsmo < (tidal_elev_m*100), 
+                           minelevsmo < (tidal_elev_m*100), 
+                           qe_ma > 0) %>%
+      pull(comid)
+  }
   
   # Identify NHM segments that overlap a "tidal" NHDPlus reach
   segs_w_tidal_comids <- filter(segs_w_comids, comid %in% comids_tidal) %>%

--- a/2_process/src/subset_tidal_reaches.R
+++ b/2_process/src/subset_tidal_reaches.R
@@ -21,5 +21,5 @@ subset_tidal_reaches <- function(reach_sf, segs_w_comids){
   
   # Subset and return NHM segments that overlap a "tidal" NHDPlus reach
   tidal_reaches <- filter(reach_sf, subsegid %in% segs_w_tidal_comids)
-  return(tidal_reaches)
+  return(tidal_reaches$subsegid)
 }

--- a/2_process/src/subset_tidal_reaches.R
+++ b/2_process/src/subset_tidal_reaches.R
@@ -1,0 +1,25 @@
+subset_tidal_reaches <- function(reach_sf, segs_w_comids){
+  #' Subset tidally-influenced PRMS segments
+  #' 
+  #' @details
+  #' A PRMS segment may be tidal if at least one overlapping NHDPlusv2 COMID
+  #' is labeled as "tidal == 1" in NHDPlus.
+  #' 
+  #' @param reach_sf sf object of reach polylines with column "subsegid"
+  #' @param segs_w_comids data frame containing the PRMS segment ids and the 
+  #' NHDPlusv2 COMIDs of interest. Must contain columns "PRMS_segid" and "comid"
+  #' 
+
+  # Download NHDv2 COMIDs that lie along NHM network, then subset "tidal" COMIDs 
+  nhdv2_flines <- nhdplusTools::get_nhdplus(comid = segs_w_comids$comid, realization = "flowline")
+  comids_tidal <- nhdv2_flines$comid[nhdv2_flines$tidal == 1]
+  
+  # Identify NHM segments that overlap a "tidal" NHDPlus reach
+  segs_w_tidal_comids <- filter(segs_w_comids, comid %in% comids_tidal) %>%
+    pull(PRMS_segid) %>%
+    unique()
+  
+  # Subset and return NHM segments that overlap a "tidal" NHDPlus reach
+  tidal_reaches <- filter(reach_sf, subsegid %in% segs_w_tidal_comids)
+  return(tidal_reaches)
+}


### PR DESCRIPTION
This PR adds a new target `p2_tidal_reaches_sf` that represents the subset of PRMS segments that may be tidally-influenced. We assume these reaches are tidal based solely on the `tidal` attribute from NHDPlus. 

To work with the NHDPlus data I've also added a new helper target, `p2_drb_comids_seg`, that contains the NHDPlusV2 COMID's that intersect/overlap the PRMS network. This code subsets these "mainstem" COMIDs to retain those with `tidal == 1` in the NHDPlus attribute table. Using the crosswalk table, I assumed all PRMS segments with at least one "tidal" COMID are also tidal. As we've discussed, this assumption is probably conservative and so I'm happy to continue that discussion and iterate our methods here. 

I have a couple small questions: 

- I haven't run the pipeline or committed the meta file because it's been awhile since I've interacted with the repo. Let me know if you have a preference for what I should do.
- Right now the tidal reaches subset is formatted as an `sf` data frame. Do you have a preference between that output versus a character string with the tidal `subsegid`?


![image](https://github.com/USGS-R/drb-inland-salinity-ml/assets/8785034/a8820c6b-cb7c-402f-ae6e-5d5124ecd139)

Relates to #241 

